### PR TITLE
Добавлены универсальные функции env и array_get

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,4 +1,56 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Copyright (c) 2025. Vitaliy Kamelin <v.kamelin@gmail.com>
  */
+
+if (!function_exists('env')) {
+    /**
+     * Get the value of an environment variable or return the default value.
+     */
+    function env(string $key, mixed $default = null): mixed
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+        if ($value === false || $value === null) {
+            return $default;
+        }
+        $value = trim((string) $value);
+        return match (strtolower($value)) {
+            'true', '(true)' => true,
+            'false', '(false)' => false,
+            'empty', '(empty)' => '',
+            'null', '(null)' => null,
+            default => $value,
+        };
+    }
+}
+
+if (!function_exists('array_get')) {
+    /**
+     * Retrieve an item from an array using "dot" notation.
+     *
+     * @param array<mixed> $array
+     * @param string|int|null $key
+     * @param mixed $default
+     */
+    function array_get(array $array, string|int|null $key, mixed $default = null): mixed
+    {
+        if ($key === null || $key === '') {
+            return $array;
+        }
+        if (array_key_exists($key, $array)) {
+            return $array[$key];
+        }
+        $segments = is_int($key) ? [$key] : explode('.', (string) $key);
+        foreach ($segments as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return $default;
+            }
+        }
+        return $array;
+    }
+}

--- a/tests/Unit/Support/HelpersTest.php
+++ b/tests/Unit/Support/HelpersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class HelpersTest extends TestCase
+{
+    public function testEnvReturnsSetValue(): void
+    {
+        $_ENV['FOO'] = 'bar';
+        putenv('FOO=bar');
+
+        $this->assertSame('bar', env('FOO'));
+    }
+
+    public function testEnvReturnsDefaultWhenMissing(): void
+    {
+        unset($_ENV['MISSING'], $_SERVER['MISSING']);
+        putenv('MISSING');
+
+        $this->assertSame('default', env('MISSING', 'default'));
+    }
+
+    public function testEnvCastsBoolean(): void
+    {
+        $_ENV['APP_DEBUG'] = 'true';
+        putenv('APP_DEBUG=true');
+
+        $this->assertTrue(env('APP_DEBUG'));
+    }
+
+    public function testArrayGetReturnsNestedValue(): void
+    {
+        $data = ['a' => ['b' => ['c' => 'value']]];
+
+        $this->assertSame('value', array_get($data, 'a.b.c'));
+    }
+
+    public function testArrayGetReturnsDefaultForMissingKey(): void
+    {
+        $data = ['a' => ['b' => ['c' => 'value']]];
+
+        $this->assertSame('default', array_get($data, 'a.b.d', 'default'));
+    }
+}


### PR DESCRIPTION
## Summary
- добавить глобальные функции `env()` и `array_get()`
- покрыть вспомогательные функции unit-тестами

## Testing
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6997388f8832d941f0bafa18895a6