### PR TITLE
Добавить провайдер логирования на базе Monolog

### DIFF
--- a/src/Bootstrap/Kernel.php
+++ b/src/Bootstrap/Kernel.php
@@ -20,6 +20,7 @@ namespace Setka\Cms\Bootstrap;
 use Setka\Cms\Bootstrap\Providers\CacheProvider;
 use Setka\Cms\Bootstrap\Providers\DatabaseProvider;
 use Setka\Cms\Bootstrap\Providers\EventProvider;
+use Setka\Cms\Bootstrap\Providers\LogProvider;
 use Setka\Cms\Bootstrap\Providers\ProviderInterface;
 use yii\base\Application as YiiApplication;
 use yii\base\BootstrapInterface;
@@ -34,6 +35,7 @@ final class Kernel implements BootstrapInterface
         CacheProvider::class,
         DatabaseProvider::class,
         EventProvider::class,
+        LogProvider::class,
     ];
 
     public function __construct(private string $projectRoot)

--- a/src/Bootstrap/Providers/LogProvider.php
+++ b/src/Bootstrap/Providers/LogProvider.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+namespace Setka\Cms\Bootstrap\Providers;
+
+use Psr\Log\LoggerInterface;
+use Setka\Cms\Infrastructure\Log\MonologLogger;
+use yii\di\Container;
+
+class LogProvider implements ProviderInterface
+{
+    public function register(Container $c, array $params = []): void
+    {
+        $config = $params['log'] ?? [];
+        $name = $config['name'] ?? 'app';
+        $stream = $config['stream'] ?? 'php://stdout';
+
+        $c->set(LoggerInterface::class, static fn() => new MonologLogger($name, $stream));
+        $c->set('logger', LoggerInterface::class);
+    }
+}
+

--- a/src/Infrastructure/Log/MonologLogger.php
+++ b/src/Infrastructure/Log/MonologLogger.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\Log;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+
+final class MonologLogger extends Logger
+{
+    public function __construct(string $name = 'app', string $stream = 'php://stdout', Level $level = Level::Debug)
+    {
+        parent::__construct($name);
+        $this->pushHandler(new StreamHandler($stream, $level));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Добавлен `LogProvider` для регистрации `LoggerInterface` через `MonologLogger`
- Реализован класс `Infrastructure\Log\MonologLogger`
- Провайдер логирования подключён в `Kernel`

## Testing
- `composer test` *(ошибка: phpunit: not found)*
- `composer install` *(ошибка загрузки зависимостей: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b0e8831c832d9d8893f1efa199fd