### PR TITLE
Добавлена поддержка OAuth-клиентов

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -8,6 +8,8 @@ use Setka\Cms\Http\Dashboard\Module as DashboardModule;
 use Setka\Cms\Http\Front\Module as FrontModule;
 use Setka\Cms\Http\Api\GraphQL\Module as GraphqlModule;
 use yii\rest\UrlRule;
+use yii\authclient\clients\VKontakte;
+use yii\authclient\clients\YandexOAuth;
 
 return [
     'id' => 'setka-web',
@@ -63,4 +65,18 @@ return [
     ],
     // Root route maps to the Front module
     'defaultRoute' => 'front',
+    'params' => [
+        'authClients' => [
+            'vkontakte' => [
+                'class' => VKontakte::class,
+                'clientId' => env('VK_CLIENT_ID', ''),
+                'clientSecret' => env('VK_CLIENT_SECRET', ''),
+            ],
+            'yandex' => [
+                'class' => YandexOAuth::class,
+                'clientId' => env('YANDEX_CLIENT_ID', ''),
+                'clientSecret' => env('YANDEX_CLIENT_SECRET', ''),
+            ],
+        ],
+    ],
 ];

--- a/src/Bootstrap/Kernel.php
+++ b/src/Bootstrap/Kernel.php
@@ -21,6 +21,7 @@ use Setka\Cms\Bootstrap\Providers\CacheProvider;
 use Setka\Cms\Bootstrap\Providers\DatabaseProvider;
 use Setka\Cms\Bootstrap\Providers\EventProvider;
 use Setka\Cms\Bootstrap\Providers\GraphQLProvider;
+use Setka\Cms\Bootstrap\Providers\AuthClientProvider;
 use Setka\Cms\Bootstrap\Providers\StorageProvider;
 use Setka\Cms\Bootstrap\Providers\HttpClientProvider;
 use Setka\Cms\Bootstrap\Providers\LogProvider;
@@ -43,6 +44,7 @@ final class Kernel implements BootstrapInterface
         EventProvider::class,
         GraphQLProvider::class,
         HttpClientProvider::class,
+        AuthClientProvider::class,
         LogProvider::class,
         QueueProvider::class,
         RbacProvider::class,

--- a/src/Bootstrap/Providers/AuthClientProvider.php
+++ b/src/Bootstrap/Providers/AuthClientProvider.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+namespace Setka\Cms\Bootstrap\Providers;
+
+use yii\authclient\Collection;
+use yii\di\Container;
+
+class AuthClientProvider implements ProviderInterface
+{
+    public function register(Container $c, array $params = []): void
+    {
+        $clients = $params['authClients'] ?? [];
+
+        $c->set(Collection::class, static fn() => new Collection(['clients' => $clients]));
+        $c->set('authClientCollection', Collection::class);
+    }
+}

--- a/src/Infrastructure/Auth/OAuthService.php
+++ b/src/Infrastructure/Auth/OAuthService.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\Auth;
+
+use yii\authclient\ClientInterface;
+use yii\authclient\Collection;
+
+final class OAuthService
+{
+    public function __construct(private readonly Collection $clients)
+    {
+    }
+
+    public function getClient(string $name): ClientInterface
+    {
+        return $this->clients->getClient($name);
+    }
+
+    public function buildAuthUrl(string $name): string
+    {
+        return $this->getClient($name)->buildAuthUrl();
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function fetchUser(string $name, array $params): array
+    {
+        /** @var ClientInterface&\yii\authclient\OAuth2 $client */
+        $client = $this->getClient($name);
+        $client->fetchAccessToken($params);
+
+        return $client->getUserAttributes();
+    }
+}


### PR DESCRIPTION
## Summary
- register OAuth clients collection
- add OAuthService for authorization via external providers
- configure VK and Yandex auth clients

## Testing
- `composer test` *(fails: phpunit: not found)*
- `composer cs` *(fails: php-cs-fixer: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c6c18a90832d99942d62bcb05151