### PR TITLE
Use DashboardAsset for dashboard layouts

### DIFF
--- a/src/Http/Dashboard/Assets/DashboardAsset.php
+++ b/src/Http/Dashboard/Assets/DashboardAsset.php
@@ -13,9 +13,13 @@ class DashboardAsset extends AssetBundle
 {
     public $sourcePath = __DIR__ . '/dist';
 
-    public $css = [];
+    public $css = [
+        'css/dashboard.css',
+    ];
 
-    public $js = [];
+    public $js = [
+        'js/dashboard.js',
+    ];
 
     public $depends = [
         \dmstr\web\AdminLteAsset::class,

--- a/src/Http/Dashboard/Assets/dist/css/dashboard.css
+++ b/src/Http/Dashboard/Assets/dist/css/dashboard.css
@@ -1,0 +1,3 @@
+/*
+ * Custom styles for the Setka CMS dashboard module.
+ */

--- a/src/Http/Dashboard/Assets/dist/js/dashboard.js
+++ b/src/Http/Dashboard/Assets/dist/js/dashboard.js
@@ -1,0 +1,1 @@
+// Custom scripts for the Setka CMS dashboard module.

--- a/src/Http/Dashboard/Module.php
+++ b/src/Http/Dashboard/Module.php
@@ -7,7 +7,6 @@
 
 namespace Setka\Cms\Http\Dashboard;
 
-use dmstr\web\AdminLteAsset;
 use RuntimeException;
 use yii\base\Module as BaseModule;
 

--- a/src/Http/Dashboard/Views/layouts/main-login.php
+++ b/src/Http/Dashboard/Views/layouts/main-login.php
@@ -1,11 +1,12 @@
 <?php
 
+use Setka\Cms\Http\Dashboard\Assets\DashboardAsset;
 use yii\helpers\Html;
 
 /* @var $this \yii\web\View */
 /* @var $content string */
 
-dmstr\web\AdminLteAsset::register($this);
+DashboardAsset::register($this);
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>

--- a/src/Http/Dashboard/Views/layouts/main.php
+++ b/src/Http/Dashboard/Views/layouts/main.php
@@ -1,5 +1,6 @@
 <?php
 
+use Setka\Cms\Http\Dashboard\Assets\DashboardAsset;
 use yii\helpers\Html;
 use yii\web\View;
 
@@ -12,7 +13,7 @@ if (Yii::$app->controller->action->id === 'login') {
     );
     return;
 }
-dmstr\web\AdminLteAsset::register($this);
+DashboardAsset::register($this);
 $directoryAsset = Yii::$app->assetManager->getPublishedUrl('@vendor/almasaeed2010/adminlte/dist');
 ?>
 <?php $this->beginPage() ?>


### PR DESCRIPTION
## Summary
- replace direct AdminLte registrations in dashboard layouts with the new DashboardAsset bundle
- extend DashboardAsset to publish placeholder CSS and JS while depending on AdminLte
- drop the unused AdminLte import from the dashboard module

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c944dee218832daaa8b54404fa5de2