### PR TITLE
Добавить поддержку таксономий в домене и интерфейсе

### DIFF
--- a/migrations/m250918_090000_create_taxonomy_tables.php
+++ b/migrations/m250918_090000_create_taxonomy_tables.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+use yii\db\Migration;
+
+/**
+ * Создаёт таблицы таксономий, терминов и связей с элементами.
+ */
+final class m250918_090000_create_taxonomy_tables extends Migration
+{
+    public function safeUp(): void
+    {
+        $this->createTable('{{%taxonomy}}', [
+            'id' => $this->primaryKey(),
+            'uid' => $this->char(32)->notNull(),
+            'workspace_id' => $this->integer()->notNull(),
+            'collection_id' => $this->integer()->notNull(),
+            'handle' => $this->string(190)->notNull(),
+            'name' => $this->string(190)->notNull(),
+            'structure' => $this->string(16)->notNull()->defaultValue('flat'),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_taxonomy_uid', '{{%taxonomy}}', 'uid', true);
+        $this->createIndex('ux_taxonomy_collection_handle', '{{%taxonomy}}', ['collection_id', 'handle'], true);
+        $this->addForeignKey('fk_taxonomy_workspace', '{{%taxonomy}}', 'workspace_id', '{{%workspace}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_taxonomy_collection', '{{%taxonomy}}', 'collection_id', '{{%collection}}', 'id', 'CASCADE', 'CASCADE');
+
+        $this->createTable('{{%term}}', [
+            'id' => $this->primaryKey(),
+            'uid' => $this->char(32)->notNull(),
+            'taxonomy_id' => $this->integer()->notNull(),
+            'parent_id' => $this->integer()->null(),
+            'slug' => $this->string(190)->notNull(),
+            'name' => $this->string(190)->notNull(),
+            'locale' => $this->string(12)->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_term_uid', '{{%term}}', 'uid', true);
+        $this->createIndex('ux_term_taxonomy_locale_slug', '{{%term}}', ['taxonomy_id', 'locale', 'slug'], true);
+        $this->createIndex('idx_term_parent', '{{%term}}', 'parent_id');
+        $this->createIndex('idx_term_taxonomy_position', '{{%term}}', ['taxonomy_id', 'position']);
+        $this->addForeignKey('fk_term_taxonomy', '{{%term}}', 'taxonomy_id', '{{%taxonomy}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_term_parent', '{{%term}}', 'parent_id', '{{%term}}', 'id', 'CASCADE', 'CASCADE');
+
+        $this->createTable('{{%element_term}}', [
+            'id' => $this->primaryKey(),
+            'element_id' => $this->integer()->notNull(),
+            'term_id' => $this->integer()->notNull(),
+            'taxonomy_id' => $this->integer()->notNull(),
+            'workspace_id' => $this->integer()->notNull(),
+            'locale' => $this->string(12)->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_element_term_unique', '{{%element_term}}', ['element_id', 'term_id', 'locale'], true);
+        $this->createIndex('idx_element_term_term', '{{%element_term}}', 'term_id');
+        $this->createIndex('idx_element_term_taxonomy', '{{%element_term}}', 'taxonomy_id');
+        $this->createIndex('idx_element_term_workspace', '{{%element_term}}', 'workspace_id');
+        $this->createIndex('idx_element_term_locale', '{{%element_term}}', 'locale');
+        $this->addForeignKey('fk_element_term_element', '{{%element_term}}', 'element_id', '{{%element}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_element_term_term', '{{%element_term}}', 'term_id', '{{%term}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_element_term_taxonomy', '{{%element_term}}', 'taxonomy_id', '{{%taxonomy}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_element_term_workspace', '{{%element_term}}', 'workspace_id', '{{%workspace}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown(): void
+    {
+        $this->dropForeignKey('fk_element_term_workspace', '{{%element_term}}');
+        $this->dropForeignKey('fk_element_term_taxonomy', '{{%element_term}}');
+        $this->dropForeignKey('fk_element_term_term', '{{%element_term}}');
+        $this->dropForeignKey('fk_element_term_element', '{{%element_term}}');
+        $this->dropTable('{{%element_term}}');
+
+        $this->dropForeignKey('fk_term_parent', '{{%term}}');
+        $this->dropForeignKey('fk_term_taxonomy', '{{%term}}');
+        $this->dropTable('{{%term}}');
+
+        $this->dropForeignKey('fk_taxonomy_collection', '{{%taxonomy}}');
+        $this->dropForeignKey('fk_taxonomy_workspace', '{{%taxonomy}}');
+        $this->dropTable('{{%taxonomy}}');
+    }
+}

--- a/src/Domain/Taxonomy/Taxonomy.php
+++ b/src/Domain/Taxonomy/Taxonomy.php
@@ -1,0 +1,312 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Taxonomy;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+/**
+ * Таксономия для группировки элементов.
+ */
+class Taxonomy
+{
+    private ?int $id;
+
+    private string $uid;
+
+    private Workspace $workspace;
+
+    private string $handle;
+
+    private string $name;
+
+    private TaxonomyStructure $structure;
+
+    /** @var array<string, Term> */
+    private array $terms = [];
+
+    /** @var array<int, Term> */
+    private array $termsById = [];
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Workspace $workspace,
+        string $handle,
+        string $name,
+        TaxonomyStructure $structure = TaxonomyStructure::FLAT,
+        ?int $id = null,
+        ?string $uid = null
+    ) {
+        $this->workspace = $workspace;
+        $this->handle = $this->assertHandle($handle);
+        $this->name = $this->assertName($name);
+        $this->structure = $structure;
+        $this->id = $id;
+        $this->uid = $uid ?? self::generateUid();
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public static function generateUid(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function getWorkspace(): Workspace
+    {
+        return $this->workspace;
+    }
+
+    public function getHandle(): string
+    {
+        return $this->handle;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name): void
+    {
+        $normalised = $this->assertName($name);
+        if ($this->name === $normalised) {
+            return;
+        }
+
+        $this->name = $normalised;
+        $this->touch();
+    }
+
+    public function getStructure(): TaxonomyStructure
+    {
+        return $this->structure;
+    }
+
+    public function setStructure(TaxonomyStructure $structure): void
+    {
+        if ($this->structure === $structure) {
+            return;
+        }
+
+        $this->structure = $structure;
+        $this->touch();
+    }
+
+    public function isFlat(): bool
+    {
+        return $this->structure->isFlat();
+    }
+
+    public function isTree(): bool
+    {
+        return $this->structure->isTree();
+    }
+
+    /**
+     * @return Term[]
+     */
+    public function getTerms(?string $locale = null): array
+    {
+        $terms = array_values($this->terms);
+        if ($locale === null) {
+            return $terms;
+        }
+
+        return array_values(array_filter(
+            $terms,
+            static fn(Term $term): bool => $term->getLocale() === $locale
+        ));
+    }
+
+    /**
+     * @return Term[]
+     */
+    public function getRootTerms(?string $locale = null): array
+    {
+        $terms = array_filter(
+            $this->terms,
+            static fn(Term $term): bool => $term->getParent() === null
+        );
+        if ($locale !== null) {
+            $terms = array_filter(
+                $terms,
+                static fn(Term $term): bool => $term->getLocale() === $locale
+            );
+        }
+
+        usort($terms, static fn(Term $a, Term $b): int => $a->getPosition() <=> $b->getPosition());
+
+        return array_values($terms);
+    }
+
+    public function addTerm(Term $term): void
+    {
+        if ($term->getTaxonomy() !== $this) {
+            throw new InvalidArgumentException('Term belongs to a different taxonomy.');
+        }
+
+        $uid = $term->getUid();
+        $existing = $this->terms[$uid] ?? null;
+        if ($existing === $term) {
+            return;
+        }
+
+        $this->terms[$uid] = $term;
+        $id = $term->getId();
+        if ($id !== null) {
+            $this->termsById[$id] = $term;
+        }
+
+        $this->touch();
+    }
+
+    public function removeTerm(Term $term): void
+    {
+        if ($term->getTaxonomy() !== $this) {
+            return;
+        }
+
+        $uid = $term->getUid();
+        if (!isset($this->terms[$uid])) {
+            return;
+        }
+
+        unset($this->terms[$uid]);
+        $id = $term->getId();
+        if ($id !== null) {
+            unset($this->termsById[$id]);
+        }
+
+        foreach ($term->getChildren() as $child) {
+            $child->setParent(null);
+        }
+
+        if ($term->getParent() !== null) {
+            $term->setParent(null);
+        }
+
+        $this->touch();
+    }
+
+    public function findTermById(int $id): ?Term
+    {
+        return $this->termsById[$id] ?? null;
+    }
+
+    public function findTermByUid(string $uid): ?Term
+    {
+        return $this->terms[$uid] ?? null;
+    }
+
+    /**
+     * @return array<int, array{term: Term, children: array<int, array{term: Term, children: array}>}>
+     */
+    public function buildTree(string $locale): array
+    {
+        $roots = $this->getRootTerms($locale);
+
+        return array_map(
+            fn(Term $term): array => $this->mapTermToNode($term, $locale),
+            $roots
+        );
+    }
+
+    public function clearTerms(): void
+    {
+        if ($this->terms === []) {
+            return;
+        }
+
+        $this->terms = [];
+        $this->termsById = [];
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function mapTermToNode(Term $term, string $locale): array
+    {
+        $children = array_filter(
+            $term->getChildren(),
+            static fn(Term $child): bool => $child->getLocale() === $locale
+        );
+        usort($children, static fn(Term $a, Term $b): int => $a->getPosition() <=> $b->getPosition());
+
+        return [
+            'term' => $term,
+            'children' => array_map(
+                fn(Term $child): array => $this->mapTermToNode($child, $locale),
+                $children
+            ),
+        ];
+    }
+
+    private function assertHandle(string $handle): string
+    {
+        $handle = strtolower(trim($handle));
+        if ($handle === '') {
+            throw new InvalidArgumentException('Taxonomy handle must not be empty.');
+        }
+
+        if (!preg_match('/^[a-z0-9][a-z0-9_\-]*$/', $handle)) {
+            throw new InvalidArgumentException('Taxonomy handle contains invalid characters.');
+        }
+
+        return $handle;
+    }
+
+    private function assertName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new InvalidArgumentException('Taxonomy name must not be empty.');
+        }
+
+        return $name;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/src/Domain/Taxonomy/TaxonomyService.php
+++ b/src/Domain/Taxonomy/TaxonomyService.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Taxonomy;
+
+use Setka\Cms\Domain\Elements\Element;
+
+final class TaxonomyService
+{
+    /**
+     * @param Element[] $elements
+     * @return Element[]
+     */
+    public function filterElementsByTerms(array $elements, Term ...$terms): array
+    {
+        if ($terms === []) {
+            return $elements;
+        }
+
+        $unique = [];
+        foreach ($terms as $term) {
+            $unique[$term->getUid()] = $term;
+        }
+
+        return array_values(array_filter(
+            $elements,
+            static function (Element $element) use ($unique): bool {
+                foreach ($unique as $term) {
+                    if (!$element->hasTerm($term)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        ));
+    }
+
+    /**
+     * @return array<int, array{term: Term, children: array}>
+     */
+    public function buildTree(Taxonomy $taxonomy, string $locale): array
+    {
+        return $taxonomy->buildTree($locale);
+    }
+}

--- a/src/Domain/Taxonomy/TaxonomyStructure.php
+++ b/src/Domain/Taxonomy/TaxonomyStructure.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Taxonomy;
+
+enum TaxonomyStructure: string
+{
+    case FLAT = 'flat';
+    case TREE = 'tree';
+
+    public function isFlat(): bool
+    {
+        return $this === self::FLAT;
+    }
+
+    public function isTree(): bool
+    {
+        return $this === self::TREE;
+    }
+}

--- a/src/Domain/Taxonomy/Term.php
+++ b/src/Domain/Taxonomy/Term.php
@@ -1,0 +1,289 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Taxonomy;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+/**
+ * Термин таксономии.
+ */
+class Term
+{
+    private ?int $id;
+
+    private string $uid;
+
+    private Taxonomy $taxonomy;
+
+    private string $slug;
+
+    private string $name;
+
+    private string $locale;
+
+    private int $position;
+
+    private ?self $parent = null;
+
+    /** @var array<string, self> */
+    private array $children = [];
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Taxonomy $taxonomy,
+        string $slug,
+        string $name,
+        string $locale,
+        int $position = 0,
+        ?int $id = null,
+        ?string $uid = null
+    ) {
+        $this->taxonomy = $taxonomy;
+        $this->slug = $this->assertSlug($slug);
+        $this->name = $this->assertName($name);
+        $this->locale = $this->assertLocale($locale);
+        $this->position = $this->assertPosition($position);
+        $this->id = $id;
+        $this->uid = $uid ?? self::generateUid();
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public static function generateUid(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function getTaxonomy(): Taxonomy
+    {
+        return $this->taxonomy;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): void
+    {
+        $normalised = $this->assertSlug($slug);
+        if ($this->slug === $normalised) {
+            return;
+        }
+
+        $this->slug = $normalised;
+        $this->touch();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name): void
+    {
+        $normalised = $this->assertName($name);
+        if ($this->name === $normalised) {
+            return;
+        }
+
+        $this->name = $normalised;
+        $this->touch();
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $position = $this->assertPosition($position);
+        if ($this->position === $position) {
+            return;
+        }
+
+        $this->position = $position;
+        $this->touch();
+    }
+
+    public function getParent(): ?self
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?self $parent): void
+    {
+        if ($parent === $this) {
+            throw new InvalidArgumentException('Term cannot be its own parent.');
+        }
+
+        if ($parent !== null) {
+            if ($parent->getTaxonomy() !== $this->taxonomy) {
+                throw new InvalidArgumentException('Parent term must belong to the same taxonomy.');
+            }
+
+            $this->assertNoCycle($parent);
+        }
+
+        if ($this->parent === $parent) {
+            return;
+        }
+
+        if ($this->parent !== null) {
+            unset($this->parent->children[$this->uid]);
+        }
+
+        $this->parent = $parent;
+        if ($parent !== null) {
+            $parent->children[$this->uid] = $this;
+        }
+
+        $this->touch();
+    }
+
+    public function addChild(self $child): void
+    {
+        $child->setParent($this);
+    }
+
+    public function removeChild(self $child): void
+    {
+        if (!isset($this->children[$child->uid])) {
+            return;
+        }
+
+        $child->setParent(null);
+    }
+
+    public function isRoot(): bool
+    {
+        return $this->parent === null;
+    }
+
+    public function isLeaf(): bool
+    {
+        return $this->children === [];
+    }
+
+    /**
+     * @return self[]
+     */
+    public function getChildren(): array
+    {
+        $children = $this->children;
+        usort($children, static fn(self $a, self $b): int => $a->position <=> $b->position);
+
+        return array_values($children);
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function assertSlug(string $slug): string
+    {
+        $slug = strtolower(trim($slug));
+        if ($slug === '') {
+            throw new InvalidArgumentException('Term slug must not be empty.');
+        }
+
+        if (!preg_match('/^[a-z0-9][a-z0-9_\-]*$/', $slug)) {
+            throw new InvalidArgumentException('Term slug contains invalid characters.');
+        }
+
+        return $slug;
+    }
+
+    private function assertName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new InvalidArgumentException('Term name must not be empty.');
+        }
+
+        return $name;
+    }
+
+    private function assertLocale(string $locale): string
+    {
+        $locale = trim($locale);
+        if ($locale === '') {
+            throw new InvalidArgumentException('Term locale must not be empty.');
+        }
+
+        if (!$this->taxonomy->getWorkspace()->supportsLocale($locale)) {
+            throw new InvalidArgumentException(sprintf('Locale "%s" is not supported by workspace.', $locale));
+        }
+
+        return $locale;
+    }
+
+    private function assertPosition(int $position): int
+    {
+        if ($position < 0) {
+            throw new InvalidArgumentException('Term position must be non-negative.');
+        }
+
+        return $position;
+    }
+
+    private function assertNoCycle(self $parent): void
+    {
+        $current = $parent;
+        while ($current !== null) {
+            if ($current === $this) {
+                throw new InvalidArgumentException('Cyclical term hierarchy detected.');
+            }
+
+            $current = $current->parent;
+        }
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/src/Http/Dashboard/Controllers/IndexController.php
+++ b/src/Http/Dashboard/Controllers/IndexController.php
@@ -7,13 +7,42 @@
 
 namespace Setka\Cms\Http\Dashboard\Controllers;
 
+use Setka\Cms\Domain\Elements\Collection;
+use Setka\Cms\Domain\Taxonomy\Taxonomy;
+use Setka\Cms\Domain\Taxonomy\TaxonomyService;
+use Setka\Cms\Domain\Taxonomy\TaxonomyStructure;
+use Setka\Cms\Domain\Taxonomy\Term;
+use Setka\Cms\Domain\Workspaces\Workspace;
 use yii\web\Controller;
 
 class IndexController extends Controller
 {
     public function actionIndex(): string
     {
-        return $this->render('index');
+        $workspace = new Workspace('default', 'Default', ['en-US']);
+        $collection = new Collection($workspace, 'articles', 'Articles');
+
+        $taxonomy = new Taxonomy($workspace, 'categories', 'Категории', TaxonomyStructure::TREE);
+        $collection->allowTaxonomy($taxonomy);
+
+        $root = new Term($taxonomy, 'news', 'Новости', 'en-US', position: 0);
+        $features = new Term($taxonomy, 'features', 'Спецпроекты', 'en-US', position: 1);
+        $world = new Term($taxonomy, 'world', 'Мир', 'en-US', position: 0);
+
+        $taxonomy->addTerm($root);
+        $taxonomy->addTerm($features);
+        $taxonomy->addTerm($world);
+
+        $world->setParent($root);
+
+        $locale = 'en-US';
+        $taxonomyTree = (new TaxonomyService())->buildTree($taxonomy, $locale);
+
+        return $this->render('index', [
+            'sampleTaxonomy' => $taxonomy,
+            'taxonomyTree' => $taxonomyTree,
+            'taxonomyLocale' => $locale,
+        ]);
     }
 }
 

--- a/src/Http/Dashboard/Views/index/index.php
+++ b/src/Http/Dashboard/Views/index/index.php
@@ -1,6 +1,47 @@
 <?php
+
+use Setka\Cms\Domain\Taxonomy\Term;
+use yii\helpers\Html;
+
 /* @var $this \yii\web\View */
+/* @var \Setka\Cms\Domain\Taxonomy\Taxonomy|null $sampleTaxonomy */
+/* @var array<int, array{term: Term, children: array}> $taxonomyTree */
+/* @var string $taxonomyLocale */
+
+$this->title = 'Dashboard';
 ?>
-<h1>Dashboard</h1>
+
+<h1><?= Html::encode($this->title) ?></h1>
 <p>Welcome to the Setka CMS dashboard.</p>
+
+<?php if (!empty($taxonomyTree) && isset($sampleTaxonomy, $taxonomyLocale)): ?>
+    <div class="taxonomy-preview">
+        <h2><?= Html::encode($sampleTaxonomy->getName()) ?></h2>
+        <p><?= Html::encode('Локаль отображения: ' . $taxonomyLocale) ?></p>
+        <?php
+        $renderTree = function (array $nodes) use (&$renderTree): string {
+            if ($nodes === []) {
+                return '';
+            }
+
+            $html = '<ul>';
+            foreach ($nodes as $node) {
+                /** @var Term $term */
+                $term = $node['term'];
+                $html .= '<li>' . Html::encode($term->getName());
+                if (!empty($node['children'])) {
+                    $html .= $renderTree($node['children']);
+                }
+                $html .= '</li>';
+            }
+
+            $html .= '</ul>';
+
+            return $html;
+        };
+
+        echo $renderTree($taxonomyTree);
+        ?>
+    </div>
+<?php endif; ?>
 

--- a/tests/Unit/Domain/Taxonomy/ElementTermAssignmentTest.php
+++ b/tests/Unit/Domain/Taxonomy/ElementTermAssignmentTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Taxonomy;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Setka\Cms\Domain\Elements\Collection;
+use Setka\Cms\Domain\Elements\Element;
+use Setka\Cms\Domain\Taxonomy\Taxonomy;
+use Setka\Cms\Domain\Taxonomy\TaxonomyStructure;
+use Setka\Cms\Domain\Taxonomy\Term;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+final class ElementTermAssignmentTest extends TestCase
+{
+    public function testElementTracksAssignedTerms(): void
+    {
+        $workspace = new Workspace('default', 'Default', ['en-US']);
+        $collection = new Collection($workspace, 'articles', 'Articles');
+
+        $taxonomy = new Taxonomy($workspace, 'topics', 'Topics', TaxonomyStructure::FLAT);
+        $collection->allowTaxonomy($taxonomy);
+
+        $news = new Term($taxonomy, 'news', 'News', 'en-US', position: 1, id: 1);
+        $tech = new Term($taxonomy, 'tech', 'Tech', 'en-US', position: 2, id: 2);
+        $taxonomy->addTerm($news);
+        $taxonomy->addTerm($tech);
+
+        $element = new Element($collection, 'en-US');
+        $element->assignTerm($tech, position: 3);
+        $element->assignTerm($news, position: 1);
+
+        $terms = $element->getTerms($taxonomy);
+        $this->assertSame([$news, $tech], $terms);
+        $this->assertTrue($element->hasTerm($news));
+
+        $element->removeTerm($news);
+        $this->assertFalse($element->hasTerm($news));
+        $this->assertSame([$tech], $element->getTerms($taxonomy));
+
+        $element->setTermsForTaxonomy($taxonomy, [
+            ['term' => $news, 'position' => 0],
+            ['term' => $tech, 'position' => 1],
+        ]);
+
+        $this->assertSame([$news, $tech], $element->getTerms($taxonomy));
+    }
+
+    public function testElementRejectsTermsFromUnsupportedTaxonomy(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $workspace = new Workspace('default', 'Default', ['en-US']);
+        $collection = new Collection($workspace, 'articles', 'Articles');
+
+        $taxonomy = new Taxonomy($workspace, 'topics', 'Topics');
+        $other = new Taxonomy($workspace, 'tags', 'Tags');
+        $collection->allowTaxonomy($taxonomy);
+
+        $tag = new Term($other, 'featured', 'Featured', 'en-US');
+        $other->addTerm($tag);
+
+        $element = new Element($collection, 'en-US');
+        $element->assignTerm($tag);
+    }
+}

--- a/tests/Unit/Domain/Taxonomy/TaxonomyServiceTest.php
+++ b/tests/Unit/Domain/Taxonomy/TaxonomyServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Taxonomy;
+
+use PHPUnit\Framework\TestCase;
+use Setka\Cms\Domain\Elements\Collection;
+use Setka\Cms\Domain\Elements\Element;
+use Setka\Cms\Domain\Taxonomy\Taxonomy;
+use Setka\Cms\Domain\Taxonomy\TaxonomyService;
+use Setka\Cms\Domain\Taxonomy\Term;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+final class TaxonomyServiceTest extends TestCase
+{
+    public function testFilterElementsByTerms(): void
+    {
+        $workspace = new Workspace('default', 'Default', ['en-US']);
+        $collection = new Collection($workspace, 'articles', 'Articles');
+
+        $taxonomy = new Taxonomy($workspace, 'topics', 'Topics');
+        $collection->allowTaxonomy($taxonomy);
+
+        $news = new Term($taxonomy, 'news', 'News', 'en-US');
+        $analytics = new Term($taxonomy, 'analytics', 'Analytics', 'en-US');
+        $taxonomy->addTerm($news);
+        $taxonomy->addTerm($analytics);
+
+        $elementA = new Element($collection, 'en-US');
+        $elementA->assignTerm($news);
+        $elementA->assignTerm($analytics);
+
+        $elementB = new Element($collection, 'en-US');
+        $elementB->assignTerm($news);
+
+        $service = new TaxonomyService();
+        $filtered = $service->filterElementsByTerms([$elementA, $elementB], $news, $analytics);
+
+        $this->assertSame([$elementA], $filtered);
+    }
+
+    public function testFilterWithEmptyTermsReturnsOriginalList(): void
+    {
+        $workspace = new Workspace('default', 'Default', ['en-US']);
+        $collection = new Collection($workspace, 'articles', 'Articles');
+        $element = new Element($collection, 'en-US');
+
+        $service = new TaxonomyService();
+        $this->assertSame([$element], $service->filterElementsByTerms([$element]));
+    }
+}

--- a/tests/Unit/Domain/Taxonomy/TaxonomyTest.php
+++ b/tests/Unit/Domain/Taxonomy/TaxonomyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Taxonomy;
+
+use PHPUnit\Framework\TestCase;
+use Setka\Cms\Domain\Taxonomy\Taxonomy;
+use Setka\Cms\Domain\Taxonomy\TaxonomyStructure;
+use Setka\Cms\Domain\Taxonomy\Term;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+final class TaxonomyTest extends TestCase
+{
+    public function testBuildTreeFiltersByLocale(): void
+    {
+        $workspace = new Workspace('default', 'Default', ['en-US', 'de-DE']);
+        $taxonomy = new Taxonomy($workspace, 'categories', 'Categories', TaxonomyStructure::TREE);
+
+        $rootEn = new Term($taxonomy, 'news', 'News', 'en-US', position: 0, id: 1);
+        $childEn = new Term($taxonomy, 'tech', 'Tech', 'en-US', position: 1, id: 2);
+        $rootDe = new Term($taxonomy, 'nachrichten', 'Nachrichten', 'de-DE', position: 0, id: 3);
+
+        $taxonomy->addTerm($rootEn);
+        $taxonomy->addTerm($childEn);
+        $taxonomy->addTerm($rootDe);
+
+        $childEn->setParent($rootEn);
+
+        $treeEn = $taxonomy->buildTree('en-US');
+        $this->assertCount(1, $treeEn);
+        $this->assertSame($rootEn, $treeEn[0]['term']);
+        $this->assertCount(1, $treeEn[0]['children']);
+        $this->assertSame($childEn, $treeEn[0]['children'][0]['term']);
+
+        $treeDe = $taxonomy->buildTree('de-DE');
+        $this->assertCount(1, $treeDe);
+        $this->assertSame($rootDe, $treeDe[0]['term']);
+        $this->assertSame([], $treeDe[0]['children']);
+    }
+}


### PR DESCRIPTION
## Описание
- добавлены доменные модели таксономий и терминов с сервисом для построения дерева и фильтрации
- расширены коллекции и элементы поддержкой выбора таксономий и привязки терминов, реализована загрузка данных в репозитории
- созданы миграции таблиц taxonomy, term и element_term, а также юнит-тесты и демонстрация дерева в dashboard

## Тестирование
- попытка запуска `composer test` (прервано: phpunit недоступен без установки зависимостей из интернета)


------
https://chatgpt.com/codex/tasks/task_e_68ca92128764832d89e9b2da479c9aff