### PR TITLE
Add element relation domain, repository, and API

### DIFF
--- a/migrations/m250919_120000_create_relation_table.php
+++ b/migrations/m250919_120000_create_relation_table.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+use yii\db\Migration;
+
+/**
+ * Создаёт таблицу relation для хранения связей между элементами.
+ */
+final class m250919_120000_create_relation_table extends Migration
+{
+    public function safeUp(): void
+    {
+        $this->createTable('{{%relation}}', [
+            'id' => $this->primaryKey(),
+            'from_element_id' => $this->integer()->notNull(),
+            'to_element_id' => $this->integer()->notNull(),
+            'role' => $this->string(64)->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'meta' => $this->text()->notNull()->defaultValue('{}'),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+
+        $this->createIndex('ux_relation_unique', '{{%relation}}', ['from_element_id', 'role', 'to_element_id'], true);
+        $this->createIndex('idx_relation_from_role', '{{%relation}}', ['from_element_id', 'role']);
+        $this->createIndex('idx_relation_to', '{{%relation}}', 'to_element_id');
+        $this->createIndex('idx_relation_role', '{{%relation}}', 'role');
+        $this->createIndex('idx_relation_position', '{{%relation}}', 'position');
+
+        $this->addForeignKey(
+            'fk_relation_from',
+            '{{%relation}}',
+            'from_element_id',
+            '{{%element}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+
+        $this->addForeignKey(
+            'fk_relation_to',
+            '{{%relation}}',
+            'to_element_id',
+            '{{%element}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown(): void
+    {
+        $this->dropForeignKey('fk_relation_to', '{{%relation}}');
+        $this->dropForeignKey('fk_relation_from', '{{%relation}}');
+        $this->dropTable('{{%relation}}');
+    }
+}

--- a/src/Contracts/Relations/RelationRepositoryInterface.php
+++ b/src/Contracts/Relations/RelationRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Relations;
+
+use Setka\Cms\Domain\Relations\Relation;
+use Setka\Cms\Domain\Relations\RelationCollection;
+
+interface RelationRepositoryInterface
+{
+    public function findByFrom(int $fromElementId, ?string $role = null): RelationCollection;
+
+    public function findOne(int $fromElementId, int $toElementId, string $role): ?Relation;
+
+    public function save(Relation $relation): void;
+
+    public function delete(Relation $relation): void;
+}

--- a/src/Domain/Relations/Relation.php
+++ b/src/Domain/Relations/Relation.php
@@ -1,0 +1,260 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Relations;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use function array_key_exists;
+
+final class Relation
+{
+    private ?int $id;
+
+    private int $fromElementId;
+
+    private int $toElementId;
+
+    private string $role;
+
+    private int $position;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $meta;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<int|string, mixed> $meta
+     */
+    public function __construct(
+        int $fromElementId,
+        int $toElementId,
+        string $role,
+        int $position = 0,
+        array $meta = [],
+        ?int $id = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null,
+    ) {
+        $this->fromElementId = $this->assertIdentifier($fromElementId, 'from element');
+        $this->toElementId = $this->assertIdentifier($toElementId, 'to element');
+        $this->role = $this->assertRole($role);
+        $this->position = $this->assertPosition($position);
+        $this->meta = $this->normaliseMeta($meta);
+        $this->id = $id;
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+        $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function defineId(int $id): void
+    {
+        if ($id <= 0) {
+            throw new InvalidArgumentException('Relation identifier must be a positive integer.');
+        }
+
+        if ($this->id !== null && $this->id !== $id) {
+            throw new InvalidArgumentException('Relation identifier is already defined.');
+        }
+
+        if ($this->id === $id) {
+            return;
+        }
+
+        $this->id = $id;
+    }
+
+    public function getFromElementId(): int
+    {
+        return $this->fromElementId;
+    }
+
+    public function getToElementId(): int
+    {
+        return $this->toElementId;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function changeRole(string $role): void
+    {
+        $role = $this->assertRole($role);
+        if ($this->role === $role) {
+            return;
+        }
+
+        $this->role = $role;
+        $this->touch();
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function moveToPosition(int $position): void
+    {
+        $position = $this->assertPosition($position);
+        if ($this->position === $position) {
+            return;
+        }
+
+        $this->position = $position;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    /**
+     * @param array<int|string, mixed> $meta
+     */
+    public function setMeta(array $meta): void
+    {
+        $normalised = $this->normaliseMeta($meta);
+        if ($this->meta === $normalised) {
+            return;
+        }
+
+        $this->meta = $normalised;
+        $this->touch();
+    }
+
+    public function setMetaValue(string $key, mixed $value): void
+    {
+        $key = $this->assertMetaKey($key);
+        if (array_key_exists($key, $this->meta) && $this->meta[$key] === $value) {
+            return;
+        }
+
+        $this->meta[$key] = $value;
+        $this->touch();
+    }
+
+    public function removeMetaValue(string $key): void
+    {
+        $key = $this->assertMetaKey($key);
+        if (!array_key_exists($key, $this->meta)) {
+            return;
+        }
+
+        unset($this->meta[$key]);
+        $this->touch();
+    }
+
+    public function getMetaValue(string $key, mixed $default = null): mixed
+    {
+        $key = $this->assertMetaKey($key);
+
+        return $this->meta[$key] ?? $default;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    private function assertIdentifier(int $value, string $label): int
+    {
+        if ($value <= 0) {
+            throw new InvalidArgumentException(sprintf('%s must be a positive integer.', ucfirst($label)));
+        }
+
+        return $value;
+    }
+
+    private function assertRole(string $role): string
+    {
+        $role = trim($role);
+        if ($role === '') {
+            throw new InvalidArgumentException('Relation role must not be empty.');
+        }
+
+        if (!preg_match('/^[A-Za-z0-9._:-]+$/', $role)) {
+            throw new InvalidArgumentException('Relation role contains unsupported characters.');
+        }
+
+        return $role;
+    }
+
+    private function assertPosition(int $position): int
+    {
+        if ($position < 0) {
+            throw new InvalidArgumentException('Relation position must be zero or positive.');
+        }
+
+        return $position;
+    }
+
+    private function assertMetaKey(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new InvalidArgumentException('Relation meta key must not be empty.');
+        }
+
+        return $key;
+    }
+
+    /**
+     * @param array<int|string, mixed> $meta
+     * @return array<string, mixed>
+     */
+    private function normaliseMeta(array $meta): array
+    {
+        $normalised = [];
+        foreach ($meta as $key => $value) {
+            $normalisedKey = is_string($key) ? trim($key) : trim((string) $key);
+            if ($normalisedKey === '') {
+                continue;
+            }
+
+            $normalised[$normalisedKey] = $value;
+        }
+
+        return $normalised;
+    }
+}

--- a/src/Domain/Relations/RelationCollection.php
+++ b/src/Domain/Relations/RelationCollection.php
@@ -1,0 +1,251 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Relations;
+
+use Countable;
+use IteratorAggregate;
+use Traversable;
+use function array_filter;
+use function array_key_exists;
+use function array_values;
+use function in_array;
+use function strcmp;
+use function usort;
+
+/**
+ * Коллекция связей элемента.
+ */
+final class RelationCollection implements IteratorAggregate, Countable
+{
+    /**
+     * @var Relation[]
+     */
+    private array $relations = [];
+
+    public function __construct(Relation ...$relations)
+    {
+        foreach ($relations as $relation) {
+            $this->relations[] = $relation;
+        }
+
+        $this->sortByPosition();
+    }
+
+    public function add(Relation $relation): void
+    {
+        $this->relations[] = $relation;
+        $this->sortByPosition();
+    }
+
+    public function remove(Relation $relation): void
+    {
+        foreach ($this->relations as $index => $existing) {
+            if ($existing === $relation) {
+                unset($this->relations[$index]);
+                continue;
+            }
+
+            if ($relation->getId() !== null && $existing->getId() === $relation->getId()) {
+                unset($this->relations[$index]);
+                continue;
+            }
+
+            if (
+                $existing->getFromElementId() === $relation->getFromElementId()
+                && $existing->getToElementId() === $relation->getToElementId()
+                && $existing->getRole() === $relation->getRole()
+            ) {
+                unset($this->relations[$index]);
+            }
+        }
+
+        $this->relations = array_values($this->relations);
+    }
+
+    public function removeByTarget(int $toElementId): ?Relation
+    {
+        foreach ($this->relations as $index => $relation) {
+            if ($relation->getToElementId() === $toElementId) {
+                unset($this->relations[$index]);
+                $this->relations = array_values($this->relations);
+
+                return $relation;
+            }
+        }
+
+        return null;
+    }
+
+    public function containsTarget(int $toElementId): bool
+    {
+        foreach ($this->relations as $relation) {
+            if ($relation->getToElementId() === $toElementId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getByTarget(int $toElementId): ?Relation
+    {
+        foreach ($this->relations as $relation) {
+            if ($relation->getToElementId() === $toElementId) {
+                return $relation;
+            }
+        }
+
+        return null;
+    }
+
+    public function maxPosition(): int
+    {
+        $max = -1;
+        foreach ($this->relations as $relation) {
+            $position = $relation->getPosition();
+            if ($position > $max) {
+                $max = $position;
+            }
+        }
+
+        return $max;
+    }
+
+    /**
+     * @param array<int, int> $orderedTargets
+     */
+    public function reorder(array $orderedTargets): void
+    {
+        if ($this->relations === []) {
+            return;
+        }
+
+        $map = [];
+        foreach ($this->relations as $relation) {
+            $map[$relation->getToElementId()] = $relation;
+        }
+
+        $position = 0;
+        foreach ($orderedTargets as $target) {
+            $targetId = (int) $target;
+            if (!array_key_exists($targetId, $map)) {
+                continue;
+            }
+
+            $map[$targetId]->moveToPosition($position);
+            ++$position;
+        }
+
+        foreach ($this->relations as $relation) {
+            if (in_array($relation->getToElementId(), $orderedTargets, true)) {
+                continue;
+            }
+
+            $relation->moveToPosition($position);
+            ++$position;
+        }
+
+        $this->sortByPosition();
+    }
+
+    public function sortByPosition(): void
+    {
+        usort(
+            $this->relations,
+            static function (Relation $a, Relation $b): int {
+                $roleComparison = strcmp($a->getRole(), $b->getRole());
+                if ($roleComparison !== 0) {
+                    return $roleComparison;
+                }
+
+                $positionComparison = $a->getPosition() <=> $b->getPosition();
+                if ($positionComparison !== 0) {
+                    return $positionComparison;
+                }
+
+                $aKey = $a->getId() ?? $a->getToElementId();
+                $bKey = $b->getId() ?? $b->getToElementId();
+
+                return $aKey <=> $bKey;
+            }
+        );
+    }
+
+    public function filterByRole(string $role): self
+    {
+        $filtered = array_filter(
+            $this->relations,
+            static fn(Relation $relation): bool => $relation->getRole() === $role
+        );
+
+        return new self(...array_values($filtered));
+    }
+
+    /**
+     * @return array<string, Relation[]>
+     */
+    public function groupByRole(): array
+    {
+        $grouped = [];
+        foreach ($this->relations as $relation) {
+            $grouped[$relation->getRole()][] = $relation;
+        }
+
+        foreach ($grouped as &$items) {
+            usort(
+                $items,
+                static fn(Relation $a, Relation $b): int => $a->getPosition() <=> $b->getPosition()
+            );
+        }
+        unset($items);
+
+        return $grouped;
+    }
+
+    /**
+     * @return Relation[]
+     */
+    public function toArray(): array
+    {
+        $this->sortByPosition();
+
+        return array_values($this->relations);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->relations === [];
+    }
+
+    public function count(): int
+    {
+        return count($this->relations);
+    }
+
+    /**
+     * @return Traversable<array-key, Relation>
+     */
+    public function getIterator(): Traversable
+    {
+        foreach ($this->toArray() as $relation) {
+            yield $relation;
+        }
+    }
+}

--- a/src/Domain/Relations/RelationService.php
+++ b/src/Domain/Relations/RelationService.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Relations;
+
+use Setka\Cms\Contracts\Relations\RelationRepositoryInterface;
+
+final class RelationService
+{
+    public function __construct(private readonly RelationRepositoryInterface $repository)
+    {
+    }
+
+    /**
+     * Создаёт связь между элементами. Если связь уже существует — возвращает её.
+     *
+     * @param array<int|string, mixed> $meta
+     */
+    public function attach(int $fromElementId, int $toElementId, string $role, array $meta = []): Relation
+    {
+        $existing = $this->repository->findOne($fromElementId, $toElementId, $role);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $collection = $this->repository->findByFrom($fromElementId, $role);
+        $position = $collection->maxPosition();
+        $position = $position >= 0 ? $position + 1 : 0;
+
+        $relation = new Relation($fromElementId, $toElementId, $role, $position, $meta);
+        $this->repository->save($relation);
+
+        return $relation;
+    }
+
+    public function detach(int $fromElementId, int $toElementId, string $role): void
+    {
+        $relation = $this->repository->findOne($fromElementId, $toElementId, $role);
+        if ($relation === null) {
+            return;
+        }
+
+        $this->repository->delete($relation);
+
+        $remaining = $this->repository->findByFrom($fromElementId, $role);
+        $remaining->sortByPosition();
+
+        $position = 0;
+        foreach ($remaining as $item) {
+            if ($item->getPosition() === $position) {
+                ++$position;
+                continue;
+            }
+
+            $item->moveToPosition($position);
+            ++$position;
+            $this->repository->save($item);
+        }
+    }
+
+    /**
+     * @param array<int, int> $orderedTargets
+     */
+    public function reorder(int $fromElementId, string $role, array $orderedTargets): void
+    {
+        $collection = $this->repository->findByFrom($fromElementId, $role);
+        if ($collection->isEmpty()) {
+            return;
+        }
+
+        $collection->reorder($orderedTargets);
+
+        foreach ($collection as $relation) {
+            $this->repository->save($relation);
+        }
+    }
+
+    public function list(int $fromElementId, ?string $role = null): RelationCollection
+    {
+        $collection = $this->repository->findByFrom($fromElementId, $role);
+        $collection->sortByPosition();
+
+        return $collection;
+    }
+}

--- a/src/Http/Api/Rest/Controllers/RelationController.php
+++ b/src/Http/Api/Rest/Controllers/RelationController.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ */
+
+namespace Setka\Cms\Http\Api\Rest\Controllers;
+
+use Setka\Cms\Contracts\Relations\RelationRepositoryInterface;
+use Setka\Cms\Domain\Relations\Relation;
+use Setka\Cms\Domain\Relations\RelationService;
+use Setka\Cms\Infrastructure\DBAL\Repositories\RelationRepository;
+use yii\web\BadRequestHttpException;
+use function array_map;
+use function is_numeric;
+use function is_string;
+use function trim;
+
+final class RelationController extends BaseApiController
+{
+    public function actionIndex(): array
+    {
+        $request = \Yii::$app->request;
+        $from = $request->get('from');
+
+        if ($from === null || !is_numeric($from) || (int) $from <= 0) {
+            throw new BadRequestHttpException('Parameter "from" is required and must be a positive integer.');
+        }
+
+        $roleParam = $request->get('role');
+        $role = is_string($roleParam) ? trim($roleParam) : null;
+        if ($role === '') {
+            $role = null;
+        }
+
+        $service = new RelationService($this->resolveRepository());
+        $collection = $service->list((int) $from, $role);
+
+        if ($role !== null) {
+            return [
+                'from' => (int) $from,
+                'role' => $role,
+                'relations' => array_map(
+                    fn(Relation $relation): array => $this->serialiseRelation($relation),
+                    $collection->toArray()
+                ),
+            ];
+        }
+
+        $grouped = [];
+        foreach ($collection->groupByRole() as $groupRole => $relations) {
+            $grouped[$groupRole] = array_map(
+                fn(Relation $relation): array => $this->serialiseRelation($relation),
+                $relations
+            );
+        }
+
+        return [
+            'from' => (int) $from,
+            'roles' => $grouped,
+        ];
+    }
+
+    private function resolveRepository(): RelationRepositoryInterface
+    {
+        $container = \Yii::$container;
+        if ($container->has(RelationRepositoryInterface::class)) {
+            /** @var RelationRepositoryInterface $repository */
+            $repository = $container->get(RelationRepositoryInterface::class);
+
+            return $repository;
+        }
+
+        return new RelationRepository(\Yii::$app->db);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialiseRelation(Relation $relation): array
+    {
+        return [
+            'id' => $relation->getId(),
+            'from' => $relation->getFromElementId(),
+            'to' => $relation->getToElementId(),
+            'role' => $relation->getRole(),
+            'position' => $relation->getPosition(),
+            'meta' => $relation->getMeta(),
+        ];
+    }
+}

--- a/src/Infrastructure/DBAL/Repositories/RelationRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/RelationRepository.php
@@ -1,0 +1,188 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+*/
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\DBAL\Repositories;
+
+use DateTimeImmutable;
+use Exception;
+use JsonException;
+use Setka\Cms\Contracts\Relations\RelationRepositoryInterface;
+use Setka\Cms\Domain\Relations\Relation;
+use Setka\Cms\Domain\Relations\RelationCollection;
+use yii\db\Connection;
+use yii\db\Query;
+use function array_map;
+use function is_array;
+use function is_numeric;
+use function json_decode;
+use function json_encode;
+
+final class RelationRepository implements RelationRepositoryInterface
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function findByFrom(int $fromElementId, ?string $role = null): RelationCollection
+    {
+        $query = (new Query())
+            ->from('{{%relation}}')
+            ->where(['from_element_id' => $fromElementId])
+            ->orderBy(['role' => SORT_ASC, 'position' => SORT_ASC, 'id' => SORT_ASC]);
+
+        if ($role !== null && $role !== '') {
+            $query->andWhere(['role' => $role]);
+        }
+
+        $rows = $query->all($this->db);
+        $relations = array_map(fn(array $row): Relation => $this->hydrate($row), $rows);
+
+        return new RelationCollection(...$relations);
+    }
+
+    public function findOne(int $fromElementId, int $toElementId, string $role): ?Relation
+    {
+        $row = (new Query())
+            ->from('{{%relation}}')
+            ->where([
+                'from_element_id' => $fromElementId,
+                'to_element_id' => $toElementId,
+                'role' => $role,
+            ])
+            ->one($this->db);
+
+        return $row ? $this->hydrate($row) : null;
+    }
+
+    public function save(Relation $relation): void
+    {
+        $now = time();
+        $data = [
+            'from_element_id' => $relation->getFromElementId(),
+            'to_element_id' => $relation->getToElementId(),
+            'role' => $relation->getRole(),
+            'position' => $relation->getPosition(),
+            'meta' => $this->encodeMeta($relation->getMeta()),
+            'updated_at' => $now,
+        ];
+
+        $id = $relation->getId();
+        if ($id === null) {
+            $data['created_at'] = $now;
+            $this->db->createCommand()->insert('{{%relation}}', $data)->execute();
+            $relation->defineId((int) $this->db->getLastInsertID());
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->update('{{%relation}}', $data, ['id' => $id])
+            ->execute();
+    }
+
+    public function delete(Relation $relation): void
+    {
+        $id = $relation->getId();
+        if ($id !== null) {
+            $this->db->createCommand()
+                ->delete('{{%relation}}', ['id' => $id])
+                ->execute();
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->delete(
+                '{{%relation}}',
+                [
+                    'from_element_id' => $relation->getFromElementId(),
+                    'to_element_id' => $relation->getToElementId(),
+                    'role' => $relation->getRole(),
+                ]
+            )
+            ->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): Relation
+    {
+        return new Relation(
+            fromElementId: (int) $row['from_element_id'],
+            toElementId: (int) $row['to_element_id'],
+            role: (string) $row['role'],
+            position: (int) $row['position'],
+            meta: $this->decodeMeta($row['meta'] ?? null),
+            id: isset($row['id']) ? (int) $row['id'] : null,
+            createdAt: $this->createDateTime($row['created_at'] ?? null),
+            updatedAt: $this->createDateTime($row['updated_at'] ?? null),
+        );
+    }
+
+    /**
+     * @param array<int|string, mixed>|string|null $meta
+     * @return array<string, mixed>
+     */
+    private function decodeMeta(mixed $meta): array
+    {
+        if ($meta === null || $meta === '') {
+            return [];
+        }
+
+        if (is_array($meta)) {
+            return $meta;
+        }
+
+        try {
+            $decoded = json_decode((string) $meta, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    private function encodeMeta(array $meta): string
+    {
+        try {
+            return json_encode($meta, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return '{}';
+        }
+    }
+
+    private function createDateTime(mixed $timestamp): DateTimeImmutable
+    {
+        if ($timestamp instanceof DateTimeImmutable) {
+            return $timestamp;
+        }
+
+        $value = is_numeric($timestamp) ? (int) $timestamp : time();
+
+        try {
+            return (new DateTimeImmutable())->setTimestamp($value);
+        } catch (Exception) {
+            return new DateTimeImmutable();
+        }
+    }
+}

--- a/tests/Unit/Domain/Relations/RelationServiceTest.php
+++ b/tests/Unit/Domain/Relations/RelationServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Relations;
+
+use PHPUnit\Framework\TestCase;
+use Setka\Cms\Contracts\Relations\RelationRepositoryInterface;
+use Setka\Cms\Domain\Relations\Relation;
+use Setka\Cms\Domain\Relations\RelationCollection;
+use Setka\Cms\Domain\Relations\RelationService;
+
+final class RelationServiceTest extends TestCase
+{
+    public function testAttachAssignsSequentialPositionsPerRole(): void
+    {
+        $repository = new InMemoryRelationRepository();
+        $service = new RelationService($repository);
+
+        $first = $service->attach(10, 200, 'related');
+        $second = $service->attach(10, 201, 'related');
+        $other = $service->attach(10, 300, 'recommended');
+
+        self::assertSame(0, $first->getPosition());
+        self::assertSame(1, $second->getPosition());
+        self::assertSame(0, $other->getPosition());
+
+        $related = $service->list(10, 'related')->toArray();
+        self::assertCount(2, $related);
+        self::assertSame([200, 201], array_map(static fn(Relation $relation): int => $relation->getToElementId(), $related));
+    }
+
+    public function testDetachReindexesRemainingRelations(): void
+    {
+        $repository = new InMemoryRelationRepository();
+        $service = new RelationService($repository);
+
+        $service->attach(5, 1, 'related');
+        $service->attach(5, 2, 'related');
+        $service->attach(5, 3, 'related');
+
+        $service->detach(5, 2, 'related');
+
+        $remaining = $service->list(5, 'related')->toArray();
+        self::assertCount(2, $remaining);
+        self::assertSame([1, 3], array_map(static fn(Relation $relation): int => $relation->getToElementId(), $remaining));
+        self::assertSame([0, 1], array_map(static fn(Relation $relation): int => $relation->getPosition(), $remaining));
+    }
+
+    public function testReorderUpdatesPositionsBasedOnTargetOrder(): void
+    {
+        $repository = new InMemoryRelationRepository();
+        $service = new RelationService($repository);
+
+        $service->attach(7, 10, 'related');
+        $service->attach(7, 11, 'related');
+        $service->attach(7, 12, 'related');
+
+        $service->reorder(7, 'related', [12, 10, 11]);
+
+        $ordered = $service->list(7, 'related')->toArray();
+        self::assertSame([12, 10, 11], array_map(static fn(Relation $relation): int => $relation->getToElementId(), $ordered));
+        self::assertSame([0, 1, 2], array_map(static fn(Relation $relation): int => $relation->getPosition(), $ordered));
+    }
+}
+
+final class InMemoryRelationRepository implements RelationRepositoryInterface
+{
+    /**
+     * @var array<int, Relation>
+     */
+    private array $storage = [];
+
+    private int $autoIncrement = 1;
+
+    public function findByFrom(int $fromElementId, ?string $role = null): RelationCollection
+    {
+        $items = array_filter(
+            $this->storage,
+            static function (Relation $relation) use ($fromElementId, $role): bool {
+                if ($relation->getFromElementId() !== $fromElementId) {
+                    return false;
+                }
+
+                if ($role !== null && $relation->getRole() !== $role) {
+                    return false;
+                }
+
+                return true;
+            }
+        );
+
+        return new RelationCollection(...array_values($items));
+    }
+
+    public function findOne(int $fromElementId, int $toElementId, string $role): ?Relation
+    {
+        foreach ($this->storage as $relation) {
+            if (
+                $relation->getFromElementId() === $fromElementId
+                && $relation->getToElementId() === $toElementId
+                && $relation->getRole() === $role
+            ) {
+                return $relation;
+            }
+        }
+
+        return null;
+    }
+
+    public function save(Relation $relation): void
+    {
+        if ($relation->getId() === null) {
+            $relation->defineId($this->autoIncrement++);
+        }
+
+        $this->storage[$relation->getId()] = $relation;
+    }
+
+    public function delete(Relation $relation): void
+    {
+        $id = $relation->getId();
+        if ($id !== null) {
+            unset($this->storage[$id]);
+
+            return;
+        }
+
+        foreach ($this->storage as $key => $existing) {
+            if (
+                $existing->getFromElementId() === $relation->getFromElementId()
+                && $existing->getToElementId() === $relation->getToElementId()
+                && $existing->getRole() === $relation->getRole()
+            ) {
+                unset($this->storage[$key]);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add domain model, collection, and service classes for managing element relations with roles, ordering, and metadata
- create database migration and DBAL repository to persist relations between elements
- expose REST API endpoint for listing relations by role and cover relation service behaviour with unit tests

## Testing
- `composer test` *(fails: phpunit binary unavailable in container)*


------
https://chatgpt.com/codex/tasks/task_e_68caa4182964832d903fac870c00a09d