### PR TITLE
Добавлена поддержка медиа-активов

### DIFF
--- a/migrations/m250920_100000_create_asset_tables.php
+++ b/migrations/m250920_100000_create_asset_tables.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+use yii\db\Migration;
+
+/**
+ * Создаёт таблицы медиа-активов и их привязок к элементам.
+ */
+final class m250920_100000_create_asset_tables extends Migration
+{
+    public function safeUp(): void
+    {
+        $this->createTable('{{%asset}}', [
+            'id' => $this->primaryKey(),
+            'uid' => $this->char(32)->notNull(),
+            'workspace_id' => $this->integer()->notNull(),
+            'file_name' => $this->string(255)->notNull(),
+            'storage_path' => $this->string(255)->notNull(),
+            'mime_type' => $this->string(127)->notNull(),
+            'size' => $this->bigInteger()->notNull()->defaultValue(0),
+            'meta' => $this->json()->notNull(),
+            'variants' => $this->json()->notNull(),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_asset_uid', '{{%asset}}', 'uid', true);
+        $this->createIndex('idx_asset_workspace', '{{%asset}}', 'workspace_id');
+        $this->addForeignKey('fk_asset_workspace', '{{%asset}}', 'workspace_id', '{{%workspace}}', 'id', 'CASCADE', 'CASCADE');
+
+        $this->createTable('{{%element_asset}}', [
+            'id' => $this->primaryKey(),
+            'workspace_id' => $this->integer()->notNull(),
+            'element_id' => $this->integer()->notNull(),
+            'asset_id' => $this->integer()->notNull(),
+            'role' => $this->string(64)->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'variants' => $this->json()->notNull(),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('idx_element_asset_workspace', '{{%element_asset}}', 'workspace_id');
+        $this->createIndex('idx_element_asset_element_role', '{{%element_asset}}', ['element_id', 'role']);
+        $this->createIndex('idx_element_asset_asset', '{{%element_asset}}', 'asset_id');
+        $this->createIndex('ux_element_asset_unique', '{{%element_asset}}', ['workspace_id', 'element_id', 'role', 'asset_id'], true);
+
+        $this->addForeignKey('fk_element_asset_workspace', '{{%element_asset}}', 'workspace_id', '{{%workspace}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_element_asset_element', '{{%element_asset}}', 'element_id', '{{%element}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_element_asset_asset', '{{%element_asset}}', 'asset_id', '{{%asset}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown(): void
+    {
+        $this->dropForeignKey('fk_element_asset_asset', '{{%element_asset}}');
+        $this->dropForeignKey('fk_element_asset_element', '{{%element_asset}}');
+        $this->dropForeignKey('fk_element_asset_workspace', '{{%element_asset}}');
+        $this->dropIndex('ux_element_asset_unique', '{{%element_asset}}');
+        $this->dropIndex('idx_element_asset_asset', '{{%element_asset}}');
+        $this->dropIndex('idx_element_asset_element_role', '{{%element_asset}}');
+        $this->dropIndex('idx_element_asset_workspace', '{{%element_asset}}');
+        $this->dropTable('{{%element_asset}}');
+
+        $this->dropForeignKey('fk_asset_workspace', '{{%asset}}');
+        $this->dropIndex('idx_asset_workspace', '{{%asset}}');
+        $this->dropIndex('ux_asset_uid', '{{%asset}}');
+        $this->dropTable('{{%asset}}');
+    }
+}

--- a/src/Bootstrap/Providers/StorageProvider.php
+++ b/src/Bootstrap/Providers/StorageProvider.php
@@ -22,6 +22,7 @@ use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use Setka\Cms\Infrastructure\Storage\AssetStorage;
 use Setka\Cms\Infrastructure\Storage\FlysystemStorage;
 use yii\di\Container;
 
@@ -74,6 +75,11 @@ class StorageProvider implements ProviderInterface
             return new FlysystemStorage($c->get(FilesystemOperator::class));
         });
         $c->set('storage', FlysystemStorage::class);
+
+        $c->set(AssetStorage::class, static function (Container $c) {
+            return new AssetStorage($c->get(FlysystemStorage::class));
+        });
+        $c->set('assetStorage', AssetStorage::class);
     }
 }
 

--- a/src/Contracts/Assets/AssetRepositoryInterface.php
+++ b/src/Contracts/Assets/AssetRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Assets;
+
+use Setka\Cms\Domain\Assets\Asset;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+interface AssetRepositoryInterface
+{
+    public function findById(Workspace $workspace, int $id): ?Asset;
+
+    public function findByUid(Workspace $workspace, string $uid): ?Asset;
+
+    public function save(Asset $asset): void;
+
+    public function delete(Asset $asset): void;
+}

--- a/src/Contracts/Assets/AssetStorageInterface.php
+++ b/src/Contracts/Assets/AssetStorageInterface.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Assets;
+
+interface AssetStorageInterface
+{
+    public function write(string $path, string $contents): void;
+
+    public function read(string $path): string;
+
+    public function delete(string $path): void;
+}

--- a/src/Contracts/Assets/ElementAssetRepositoryInterface.php
+++ b/src/Contracts/Assets/ElementAssetRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Assets;
+
+use Setka\Cms\Domain\Assets\ElementAsset;
+use Setka\Cms\Domain\Assets\ElementAssetCollection;
+
+interface ElementAssetRepositoryInterface
+{
+    public function findByElement(int $workspaceId, int $elementId, ?string $role = null): ElementAssetCollection;
+
+    public function findOne(int $workspaceId, int $elementId, int $assetId, string $role): ?ElementAsset;
+
+    public function save(ElementAsset $attachment): void;
+
+    public function delete(ElementAsset $attachment): void;
+}

--- a/src/Domain/Assets/Asset.php
+++ b/src/Domain/Assets/Asset.php
@@ -1,0 +1,428 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Setka\Cms\Domain\Workspaces\Workspace;
+use function array_key_exists;
+use function array_values;
+use function bin2hex;
+use function ksort;
+use function random_bytes;
+use function trim;
+
+final class Asset
+{
+    private ?int $id;
+
+    private string $uid;
+
+    private Workspace $workspace;
+
+    private string $fileName;
+
+    private string $storagePath;
+
+    private string $mimeType;
+
+    private int $size;
+
+    /** @var array<string, mixed> */
+    private array $meta;
+
+    /** @var array<string, AssetVariant> */
+    private array $variants = [];
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<string, mixed> $meta
+     * @param AssetVariant[]        $variants
+     */
+    public function __construct(
+        Workspace $workspace,
+        string $fileName,
+        string $mimeType,
+        int $size = 0,
+        ?string $storagePath = null,
+        array $meta = [],
+        array $variants = [],
+        ?int $id = null,
+        ?string $uid = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null,
+    ) {
+        $this->workspace = $workspace;
+        $this->fileName = $this->assertFileName($fileName);
+        $this->mimeType = $this->assertMimeType($mimeType);
+        $this->size = $this->assertSize($size);
+        $this->meta = $this->normaliseMeta($meta);
+        $this->id = $id;
+        $this->uid = $uid ?? self::generateUid();
+        $this->storagePath = $this->normaliseStoragePath($storagePath ?? 'assets/' . $this->uid);
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+        $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
+
+        foreach ($variants as $variant) {
+            $this->defineVariant($this->assertVariantInstance($variant));
+        }
+    }
+
+    public static function generateUid(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function defineId(int $id): void
+    {
+        if ($id <= 0) {
+            throw new InvalidArgumentException('Asset identifier must be positive.');
+        }
+
+        if ($this->id !== null && $this->id !== $id) {
+            throw new InvalidArgumentException('Asset identifier is already defined.');
+        }
+
+        if ($this->id === $id) {
+            return;
+        }
+
+        $this->id = $id;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function getWorkspace(): Workspace
+    {
+        return $this->workspace;
+    }
+
+    public function getWorkspaceId(): ?int
+    {
+        return $this->workspace->getId();
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function rename(string $fileName): void
+    {
+        $fileName = $this->assertFileName($fileName);
+        if ($this->fileName === $fileName) {
+            return;
+        }
+
+        $this->fileName = $fileName;
+        $this->touch();
+    }
+
+    public function getStoragePath(): string
+    {
+        return $this->storagePath;
+    }
+
+    public function changeStoragePath(string $storagePath): void
+    {
+        $storagePath = $this->normaliseStoragePath($storagePath);
+        if ($this->storagePath === $storagePath) {
+            return;
+        }
+
+        $this->storagePath = $storagePath;
+        $this->touch();
+    }
+
+    public function getFilePath(): string
+    {
+        return $this->storagePath . '/' . $this->fileName;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function changeMimeType(string $mimeType): void
+    {
+        $mimeType = $this->assertMimeType($mimeType);
+        if ($this->mimeType === $mimeType) {
+            return;
+        }
+
+        $this->mimeType = $mimeType;
+        $this->touch();
+    }
+
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    public function updateSize(int $size): void
+    {
+        $size = $this->assertSize($size);
+        if ($this->size === $size) {
+            return;
+        }
+
+        $this->size = $size;
+        $this->touch();
+    }
+
+    public function updateFileInfo(string $fileName, string $mimeType, int $size, ?string $storagePath = null): void
+    {
+        $this->rename($fileName);
+        $this->changeMimeType($mimeType);
+        $this->updateSize($size);
+
+        if ($storagePath !== null) {
+            $this->changeStoragePath($storagePath);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    public function setMeta(array $meta): void
+    {
+        $normalised = $this->normaliseMeta($meta);
+        if ($this->meta === $normalised) {
+            return;
+        }
+
+        $this->meta = $normalised;
+        $this->touch();
+    }
+
+    public function setMetaValue(string $key, mixed $value): void
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new InvalidArgumentException('Metadata key must not be empty.');
+        }
+
+        if (array_key_exists($key, $this->meta) && $this->meta[$key] === $value) {
+            return;
+        }
+
+        $this->meta[$key] = $value;
+        $this->touch();
+    }
+
+    public function removeMetaValue(string $key): void
+    {
+        $key = trim($key);
+        if ($key === '') {
+            return;
+        }
+
+        if (!array_key_exists($key, $this->meta)) {
+            return;
+        }
+
+        unset($this->meta[$key]);
+        $this->touch();
+    }
+
+    public function getMetaValue(string $key, mixed $default = null): mixed
+    {
+        $key = trim($key);
+        if ($key === '') {
+            return $default;
+        }
+
+        return $this->meta[$key] ?? $default;
+    }
+
+    public function hasVariant(string $name): bool
+    {
+        $name = $this->assertVariantName($name);
+
+        return array_key_exists($name, $this->variants);
+    }
+
+    public function getVariant(string $name): ?AssetVariant
+    {
+        $name = $this->assertVariantName($name);
+
+        return $this->variants[$name] ?? null;
+    }
+
+    /**
+     * @return AssetVariant[]
+     */
+    public function getVariants(): array
+    {
+        ksort($this->variants);
+
+        return array_values($this->variants);
+    }
+
+    public function defineVariant(AssetVariant $variant): void
+    {
+        $name = $variant->getName();
+        if (isset($this->variants[$name]) && $this->variants[$name]->equals($variant)) {
+            return;
+        }
+
+        $this->variants[$name] = $variant;
+        $this->touch();
+    }
+
+    public function removeVariant(string $name): void
+    {
+        $name = $this->assertVariantName($name);
+        if (!isset($this->variants[$name])) {
+            return;
+        }
+
+        unset($this->variants[$name]);
+        $this->touch();
+    }
+
+    public function clearVariants(): void
+    {
+        if ($this->variants === []) {
+            return;
+        }
+
+        $this->variants = [];
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function assertFileName(string $fileName): string
+    {
+        $fileName = trim($fileName);
+        if ($fileName === '') {
+            throw new InvalidArgumentException('Filename must not be empty.');
+        }
+
+        return $fileName;
+    }
+
+    private function assertMimeType(string $mimeType): string
+    {
+        $mimeType = trim($mimeType);
+        if ($mimeType === '') {
+            throw new InvalidArgumentException('MIME type must not be empty.');
+        }
+
+        return $mimeType;
+    }
+
+    private function assertSize(int $size): int
+    {
+        if ($size < 0) {
+            throw new InvalidArgumentException('File size must be greater or equal to zero.');
+        }
+
+        return $size;
+    }
+
+    private function normaliseStoragePath(string $storagePath): string
+    {
+        $storagePath = trim($storagePath);
+        $storagePath = ltrim($storagePath, '/');
+        $storagePath = rtrim($storagePath, '/');
+        if ($storagePath === '') {
+            throw new InvalidArgumentException('Storage path must not be empty.');
+        }
+
+        return $storagePath;
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     * @return array<string, mixed>
+     */
+    private function normaliseMeta(array $meta): array
+    {
+        $normalised = [];
+        foreach ($meta as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            $trimmedKey = trim($key);
+            if ($trimmedKey === '') {
+                continue;
+            }
+
+            $normalised[$trimmedKey] = $value;
+        }
+
+        return $normalised;
+    }
+
+    private function assertVariantName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new InvalidArgumentException('Variant name must not be empty.');
+        }
+
+        return $name;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    private function assertVariantInstance(AssetVariant $variant): AssetVariant
+    {
+        if ($variant->getName() === '') {
+            throw new InvalidArgumentException('Variant must have a name.');
+        }
+
+        return $variant;
+    }
+}

--- a/src/Domain/Assets/AssetFileService.php
+++ b/src/Domain/Assets/AssetFileService.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use InvalidArgumentException;
+use Setka\Cms\Contracts\Assets\AssetStorageInterface;
+use function strlen;
+use function trim;
+
+final class AssetFileService
+{
+    public function __construct(private readonly AssetStorageInterface $storage)
+    {
+    }
+
+    public function store(Asset $asset, string $contents, ?string $fileName = null, ?string $mimeType = null): void
+    {
+        if ($fileName !== null) {
+            $fileName = $this->normaliseFileName($fileName);
+            $asset->rename($fileName);
+        }
+
+        if ($mimeType !== null) {
+            $asset->changeMimeType($mimeType);
+        }
+
+        $path = $asset->getFilePath();
+        $this->storage->write($path, $contents);
+        $asset->updateSize(strlen($contents));
+    }
+
+    public function read(Asset $asset): string
+    {
+        return $this->storage->read($asset->getFilePath());
+    }
+
+    public function delete(Asset $asset): void
+    {
+        $this->storage->delete($asset->getFilePath());
+        $asset->updateSize(0);
+    }
+
+    private function normaliseFileName(string $fileName): string
+    {
+        $fileName = trim($fileName);
+        if ($fileName === '') {
+            throw new InvalidArgumentException('File name must not be empty.');
+        }
+
+        return $fileName;
+    }
+}

--- a/src/Domain/Assets/AssetVariant.php
+++ b/src/Domain/Assets/AssetVariant.php
@@ -1,0 +1,188 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use InvalidArgumentException;
+use function trim;
+
+final class AssetVariant
+{
+    private string $name;
+
+    private string $path;
+
+    private string $mimeType;
+
+    private int $size;
+
+    private ?int $width;
+
+    private ?int $height;
+
+    /** @var array<string, mixed> */
+    private array $meta;
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    public function __construct(
+        string $name,
+        string $path,
+        string $mimeType,
+        int $size,
+        ?int $width = null,
+        ?int $height = null,
+        array $meta = [],
+    ) {
+        $this->name = $this->assertName($name);
+        $this->path = $this->assertPath($path);
+        $this->mimeType = $this->assertMimeType($mimeType);
+        $this->size = $this->assertSize($size);
+        $this->width = $width !== null ? $this->assertDimension($width) : null;
+        $this->height = $height !== null ? $this->assertDimension($height) : null;
+        $this->meta = $meta;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: (string) ($data['name'] ?? ''),
+            path: (string) ($data['path'] ?? ''),
+            mimeType: (string) ($data['mimeType'] ?? ($data['mime_type'] ?? '')),
+            size: isset($data['size']) ? (int) $data['size'] : 0,
+            width: isset($data['width']) ? (int) $data['width'] : null,
+            height: isset($data['height']) ? (int) $data['height'] : null,
+            meta: isset($data['meta']) && is_array($data['meta']) ? $data['meta'] : [],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'path' => $this->path,
+            'mimeType' => $this->mimeType,
+            'size' => $this->size,
+            'width' => $this->width,
+            'height' => $this->height,
+            'meta' => $this->meta,
+        ];
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    public function getWidth(): ?int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): ?int
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->name === $other->name
+            && $this->path === $other->path
+            && $this->mimeType === $other->mimeType
+            && $this->size === $other->size
+            && $this->width === $other->width
+            && $this->height === $other->height
+            && $this->meta == $other->meta; // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator
+    }
+
+    private function assertName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new InvalidArgumentException('Variant name must not be empty.');
+        }
+
+        return $name;
+    }
+
+    private function assertPath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            throw new InvalidArgumentException('Variant path must not be empty.');
+        }
+
+        return ltrim($path, '/');
+    }
+
+    private function assertMimeType(string $mimeType): string
+    {
+        $mimeType = trim($mimeType);
+        if ($mimeType === '') {
+            throw new InvalidArgumentException('Variant MIME type must not be empty.');
+        }
+
+        return $mimeType;
+    }
+
+    private function assertSize(int $size): int
+    {
+        if ($size < 0) {
+            throw new InvalidArgumentException('Variant size must be greater or equal to zero.');
+        }
+
+        return $size;
+    }
+
+    private function assertDimension(int $dimension): int
+    {
+        if ($dimension <= 0) {
+            throw new InvalidArgumentException('Variant dimensions must be positive integers.');
+        }
+
+        return $dimension;
+    }
+}

--- a/src/Domain/Assets/AssetVariantService.php
+++ b/src/Domain/Assets/AssetVariantService.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use InvalidArgumentException;
+use Setka\Cms\Contracts\Assets\AssetStorageInterface;
+use function sprintf;
+use function strlen;
+use function trim;
+
+final class AssetVariantService
+{
+    public function __construct(private readonly AssetStorageInterface $storage)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    public function storeVariant(
+        Asset $asset,
+        string $variantName,
+        string $contents,
+        string $mimeType,
+        array $meta = [],
+        ?string $fileName = null,
+    ): AssetVariant {
+        $variantName = $this->normaliseVariantName($variantName);
+        $fileName = $fileName !== null ? $this->normaliseFileName($fileName) : $asset->getFileName();
+        $path = $this->buildVariantPath($asset, $variantName, $fileName);
+
+        $this->storage->write($path, $contents);
+
+        $width = isset($meta['width']) ? (int) $meta['width'] : null;
+        $height = isset($meta['height']) ? (int) $meta['height'] : null;
+
+        $variant = new AssetVariant(
+            name: $variantName,
+            path: $path,
+            mimeType: $mimeType,
+            size: strlen($contents),
+            width: $width,
+            height: $height,
+            meta: $meta,
+        );
+
+        $asset->defineVariant($variant);
+
+        return $variant;
+    }
+
+    public function deleteVariant(Asset $asset, string $variantName): void
+    {
+        $variantName = $this->normaliseVariantName($variantName);
+        $variant = $asset->getVariant($variantName);
+        if ($variant === null) {
+            return;
+        }
+
+        $this->storage->delete($variant->getPath());
+        $asset->removeVariant($variantName);
+    }
+
+    public function readVariant(Asset $asset, string $variantName): string
+    {
+        $variantName = $this->normaliseVariantName($variantName);
+        $variant = $asset->getVariant($variantName);
+        if ($variant === null) {
+            throw new InvalidArgumentException('Requested variant is not registered for the asset.');
+        }
+
+        return $this->storage->read($variant->getPath());
+    }
+
+    private function buildVariantPath(Asset $asset, string $variantName, string $fileName): string
+    {
+        return sprintf('%s/variants/%s/%s', $asset->getStoragePath(), $variantName, $fileName);
+    }
+
+    private function normaliseVariantName(string $variantName): string
+    {
+        $variantName = trim($variantName);
+        if ($variantName === '') {
+            throw new InvalidArgumentException('Variant name must not be empty.');
+        }
+
+        return $variantName;
+    }
+
+    private function normaliseFileName(string $fileName): string
+    {
+        $fileName = trim($fileName);
+        if ($fileName === '') {
+            throw new InvalidArgumentException('Variant file name must not be empty.');
+        }
+
+        return $fileName;
+    }
+}

--- a/src/Domain/Assets/ElementAsset.php
+++ b/src/Domain/Assets/ElementAsset.php
@@ -1,0 +1,297 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use function array_key_exists;
+use function array_values;
+use function in_array;
+use function array_search;
+use function trim;
+
+final class ElementAsset
+{
+    private ?int $id;
+
+    private int $workspaceId;
+
+    private int $elementId;
+
+    private int $assetId;
+
+    private string $role;
+
+    private int $position;
+
+    /** @var string[] */
+    private array $variants;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    private ?Asset $asset = null;
+
+    /**
+     * @param string[] $variants
+     */
+    public function __construct(
+        int $workspaceId,
+        int $elementId,
+        int $assetId,
+        string $role,
+        int $position = 0,
+        array $variants = [],
+        ?int $id = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null,
+    ) {
+        $this->workspaceId = $this->assertIdentifier($workspaceId, 'workspace');
+        $this->elementId = $this->assertIdentifier($elementId, 'element');
+        $this->assetId = $this->assertIdentifier($assetId, 'asset');
+        $this->role = $this->assertRole($role);
+        $this->position = $this->assertPosition($position);
+        $this->variants = $this->normaliseVariants($variants);
+        $this->id = $id;
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+        $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function defineId(int $id): void
+    {
+        if ($id <= 0) {
+            throw new InvalidArgumentException('Attachment identifier must be positive.');
+        }
+
+        if ($this->id !== null && $this->id !== $id) {
+            throw new InvalidArgumentException('Attachment identifier is already defined.');
+        }
+
+        if ($this->id === $id) {
+            return;
+        }
+
+        $this->id = $id;
+    }
+
+    public function getWorkspaceId(): int
+    {
+        return $this->workspaceId;
+    }
+
+    public function getElementId(): int
+    {
+        return $this->elementId;
+    }
+
+    public function getAssetId(): int
+    {
+        return $this->assetId;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function changeRole(string $role): void
+    {
+        $role = $this->assertRole($role);
+        if ($this->role === $role) {
+            return;
+        }
+
+        $this->role = $role;
+        $this->touch();
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function moveToPosition(int $position): void
+    {
+        $position = $this->assertPosition($position);
+        if ($this->position === $position) {
+            return;
+        }
+
+        $this->position = $position;
+        $this->touch();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getVariants(): array
+    {
+        return $this->variants;
+    }
+
+    /**
+     * @param string[] $variants
+     */
+    public function setVariants(array $variants): void
+    {
+        $normalised = $this->normaliseVariants($variants);
+        if ($this->variants === $normalised) {
+            return;
+        }
+
+        $this->variants = $normalised;
+        $this->touch();
+    }
+
+    public function addVariant(string $variant): void
+    {
+        $variant = $this->assertVariant($variant);
+        if (in_array($variant, $this->variants, true)) {
+            return;
+        }
+
+        $this->variants[] = $variant;
+        $this->touch();
+    }
+
+    public function removeVariant(string $variant): void
+    {
+        $variant = $this->assertVariant($variant);
+        $index = array_search($variant, $this->variants, true);
+        if ($index === false) {
+            return;
+        }
+
+        unset($this->variants[$index]);
+        $this->variants = array_values($this->variants);
+        $this->touch();
+    }
+
+    public function hasVariant(string $variant): bool
+    {
+        $variant = $this->assertVariant($variant);
+
+        return in_array($variant, $this->variants, true);
+    }
+
+    public function attachAsset(Asset $asset): void
+    {
+        if ($asset->getId() !== null && $asset->getId() !== $this->assetId) {
+            throw new InvalidArgumentException('Attached asset identifier mismatch.');
+        }
+
+        if ($asset->getWorkspaceId() !== null && $asset->getWorkspaceId() !== $this->workspaceId) {
+            throw new InvalidArgumentException('Asset workspace mismatch.');
+        }
+
+        $this->asset = $asset;
+    }
+
+    public function getAsset(): ?Asset
+    {
+        return $this->asset;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function assertIdentifier(int $value, string $label): int
+    {
+        if ($value <= 0) {
+            throw new InvalidArgumentException($label . ' identifier must be positive.');
+        }
+
+        return $value;
+    }
+
+    private function assertRole(string $role): string
+    {
+        $role = trim($role);
+        if ($role === '') {
+            throw new InvalidArgumentException('Role must not be empty.');
+        }
+
+        return $role;
+    }
+
+    private function assertPosition(int $position): int
+    {
+        if ($position < 0) {
+            throw new InvalidArgumentException('Position must be a non-negative integer.');
+        }
+
+        return $position;
+    }
+
+    private function assertVariant(string $variant): string
+    {
+        $variant = trim($variant);
+        if ($variant === '') {
+            throw new InvalidArgumentException('Variant name must not be empty.');
+        }
+
+        return $variant;
+    }
+
+    /**
+     * @param string[] $variants
+     * @return string[]
+     */
+    private function normaliseVariants(array $variants): array
+    {
+        $normalised = [];
+        foreach ($variants as $variant) {
+            if (!is_string($variant)) {
+                continue;
+            }
+
+            $trimmed = trim($variant);
+            if ($trimmed === '') {
+                continue;
+            }
+
+            if (array_key_exists($trimmed, $normalised)) {
+                continue;
+            }
+
+            $normalised[$trimmed] = $trimmed;
+        }
+
+        return array_values($normalised);
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/src/Domain/Assets/ElementAssetCollection.php
+++ b/src/Domain/Assets/ElementAssetCollection.php
@@ -1,0 +1,217 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use Countable;
+use IteratorAggregate;
+use Traversable;
+use function array_filter;
+use function array_values;
+use function in_array;
+use function strcmp;
+use function usort;
+
+final class ElementAssetCollection implements IteratorAggregate, Countable
+{
+    /**
+     * @var ElementAsset[]
+     */
+    private array $items = [];
+
+    public function __construct(ElementAsset ...$attachments)
+    {
+        foreach ($attachments as $attachment) {
+            $this->items[] = $attachment;
+        }
+
+        $this->sortByPosition();
+    }
+
+    public function add(ElementAsset $attachment): void
+    {
+        $this->items[] = $attachment;
+        $this->sortByPosition();
+    }
+
+    public function remove(ElementAsset $attachment): void
+    {
+        foreach ($this->items as $index => $item) {
+            if ($item === $attachment) {
+                unset($this->items[$index]);
+                continue;
+            }
+
+            if ($attachment->getId() !== null && $item->getId() === $attachment->getId()) {
+                unset($this->items[$index]);
+                continue;
+            }
+
+            if (
+                $item->getWorkspaceId() === $attachment->getWorkspaceId()
+                && $item->getElementId() === $attachment->getElementId()
+                && $item->getAssetId() === $attachment->getAssetId()
+                && $item->getRole() === $attachment->getRole()
+            ) {
+                unset($this->items[$index]);
+            }
+        }
+
+        $this->items = array_values($this->items);
+    }
+
+    public function removeByAsset(int $assetId): ?ElementAsset
+    {
+        foreach ($this->items as $index => $item) {
+            if ($item->getAssetId() === $assetId) {
+                unset($this->items[$index]);
+                $this->items = array_values($this->items);
+
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    public function containsAsset(int $assetId): bool
+    {
+        foreach ($this->items as $item) {
+            if ($item->getAssetId() === $assetId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getByAsset(int $assetId): ?ElementAsset
+    {
+        foreach ($this->items as $item) {
+            if ($item->getAssetId() === $assetId) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    public function maxPosition(): int
+    {
+        $max = -1;
+        foreach ($this->items as $item) {
+            $position = $item->getPosition();
+            if ($position > $max) {
+                $max = $position;
+            }
+        }
+
+        return $max;
+    }
+
+    /**
+     * @param array<int, int> $orderedAssetIds
+     */
+    public function reorder(array $orderedAssetIds): void
+    {
+        if ($this->items === []) {
+            return;
+        }
+
+        $map = [];
+        foreach ($this->items as $item) {
+            $map[$item->getAssetId()] = $item;
+        }
+
+        $position = 0;
+        foreach ($orderedAssetIds as $assetId) {
+            $assetKey = (int) $assetId;
+            if (!isset($map[$assetKey])) {
+                continue;
+            }
+
+            $map[$assetKey]->moveToPosition($position);
+            ++$position;
+        }
+
+        foreach ($this->items as $item) {
+            if (in_array($item->getAssetId(), $orderedAssetIds, true)) {
+                continue;
+            }
+
+            $item->moveToPosition($position);
+            ++$position;
+        }
+
+        $this->sortByPosition();
+    }
+
+    public function sortByPosition(): void
+    {
+        usort(
+            $this->items,
+            static function (ElementAsset $a, ElementAsset $b): int {
+                $roleComparison = strcmp($a->getRole(), $b->getRole());
+                if ($roleComparison !== 0) {
+                    return $roleComparison;
+                }
+
+                $positionComparison = $a->getPosition() <=> $b->getPosition();
+                if ($positionComparison !== 0) {
+                    return $positionComparison;
+                }
+
+                return $a->getAssetId() <=> $b->getAssetId();
+            }
+        );
+    }
+
+    public function filterByRole(string $role): self
+    {
+        $filtered = array_filter(
+            $this->items,
+            static fn(ElementAsset $item): bool => $item->getRole() === $role
+        );
+
+        return new self(...array_values($filtered));
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->items === [];
+    }
+
+    /**
+     * @return ElementAsset[]
+     */
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/src/Domain/Assets/ElementAssetService.php
+++ b/src/Domain/Assets/ElementAssetService.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Assets;
+
+use InvalidArgumentException;
+use Setka\Cms\Contracts\Assets\ElementAssetRepositoryInterface;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+final class ElementAssetService
+{
+    public function __construct(private readonly ElementAssetRepositoryInterface $repository)
+    {
+    }
+
+    /**
+     * @param string[] $variants
+     */
+    public function attach(Workspace $workspace, Asset $asset, int $elementId, string $role, array $variants = []): ElementAsset
+    {
+        $workspaceId = $this->requireWorkspaceId($workspace);
+        $assetId = $this->requireAssetId($asset);
+
+        $existing = $this->repository->findOne($workspaceId, $elementId, $assetId, $role);
+        if ($existing !== null) {
+            $existing->setVariants($variants);
+            $this->repository->save($existing);
+
+            return $existing;
+        }
+
+        $collection = $this->repository->findByElement($workspaceId, $elementId, $role);
+        $position = $collection->maxPosition();
+        $position = $position >= 0 ? $position + 1 : 0;
+
+        $attachment = new ElementAsset(
+            workspaceId: $workspaceId,
+            elementId: $elementId,
+            assetId: $assetId,
+            role: $role,
+            position: $position,
+            variants: $variants,
+        );
+        $attachment->attachAsset($asset);
+
+        $this->repository->save($attachment);
+
+        return $attachment;
+    }
+
+    public function detach(Workspace $workspace, Asset $asset, int $elementId, string $role): void
+    {
+        $workspaceId = $this->requireWorkspaceId($workspace);
+        $assetId = $this->requireAssetId($asset);
+
+        $attachment = $this->repository->findOne($workspaceId, $elementId, $assetId, $role);
+        if ($attachment === null) {
+            return;
+        }
+
+        $this->repository->delete($attachment);
+
+        $remaining = $this->repository->findByElement($workspaceId, $elementId, $role);
+        $remaining->sortByPosition();
+
+        $position = 0;
+        foreach ($remaining as $item) {
+            if ($item->getPosition() === $position) {
+                ++$position;
+                continue;
+            }
+
+            $item->moveToPosition($position);
+            ++$position;
+            $this->repository->save($item);
+        }
+    }
+
+    /**
+     * @param array<int, int> $orderedAssetIds
+     */
+    public function reorder(Workspace $workspace, int $elementId, string $role, array $orderedAssetIds): void
+    {
+        $workspaceId = $this->requireWorkspaceId($workspace);
+        $collection = $this->repository->findByElement($workspaceId, $elementId, $role);
+        if ($collection->isEmpty()) {
+            return;
+        }
+
+        $collection->reorder($orderedAssetIds);
+
+        foreach ($collection as $attachment) {
+            $this->repository->save($attachment);
+        }
+    }
+
+    public function list(Workspace $workspace, int $elementId, ?string $role = null): ElementAssetCollection
+    {
+        $workspaceId = $this->requireWorkspaceId($workspace);
+        $collection = $this->repository->findByElement($workspaceId, $elementId, $role);
+        $collection->sortByPosition();
+
+        return $collection;
+    }
+
+    private function requireWorkspaceId(Workspace $workspace): int
+    {
+        $workspaceId = $workspace->getId();
+        if ($workspaceId === null) {
+            throw new InvalidArgumentException('Workspace must have an identifier to manage asset attachments.');
+        }
+
+        return $workspaceId;
+    }
+
+    private function requireAssetId(Asset $asset): int
+    {
+        $assetId = $asset->getId();
+        if ($assetId === null) {
+            throw new InvalidArgumentException('Asset must be persisted before it can be attached to an element.');
+        }
+
+        return $assetId;
+    }
+}

--- a/src/Domain/Fields/FieldType.php
+++ b/src/Domain/Fields/FieldType.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Setka\Cms\Domain\Fields;
 
 use DateTimeInterface;
+use function trim;
 
 /**
  * Типы полей.
@@ -94,8 +95,20 @@ enum FieldType: string
                 return false;
             }
 
-            if (isset($item['variants']) && !is_array($item['variants'])) {
-                return false;
+            if (isset($item['variants'])) {
+                if (!is_array($item['variants'])) {
+                    return false;
+                }
+
+                foreach ($item['variants'] as $variant) {
+                    if (!is_string($variant)) {
+                        return false;
+                    }
+
+                    if (trim($variant) === '') {
+                        return false;
+                    }
+                }
             }
         }
 

--- a/src/Http/Dashboard/Controllers/IndexController.php
+++ b/src/Http/Dashboard/Controllers/IndexController.php
@@ -7,6 +7,10 @@
 
 namespace Setka\Cms\Http\Dashboard\Controllers;
 
+use Setka\Cms\Domain\Assets\Asset;
+use Setka\Cms\Domain\Assets\AssetVariant;
+use Setka\Cms\Domain\Assets\ElementAsset;
+use Setka\Cms\Domain\Assets\ElementAssetCollection;
 use Setka\Cms\Domain\Elements\Collection;
 use Setka\Cms\Domain\Taxonomy\Taxonomy;
 use Setka\Cms\Domain\Taxonomy\TaxonomyService;
@@ -19,7 +23,7 @@ class IndexController extends Controller
 {
     public function actionIndex(): string
     {
-        $workspace = new Workspace('default', 'Default', ['en-US']);
+        $workspace = new Workspace('default', 'Default', ['en-US'], globalSettings: [], id: 1);
         $collection = new Collection($workspace, 'articles', 'Articles');
 
         $taxonomy = new Taxonomy($workspace, 'categories', 'Категории', TaxonomyStructure::TREE);
@@ -38,10 +42,76 @@ class IndexController extends Controller
         $locale = 'en-US';
         $taxonomyTree = (new TaxonomyService())->buildTree($taxonomy, $locale);
 
+        $heroAsset = new Asset(
+            workspace: $workspace,
+            fileName: 'hero.jpg',
+            mimeType: 'image/jpeg',
+            size: 512_000,
+            meta: ['title' => 'Обложка раздела'],
+            id: 101,
+        );
+        $heroAsset->defineVariant(new AssetVariant(
+            name: 'thumb',
+            path: $heroAsset->getStoragePath() . '/variants/thumb/hero.jpg',
+            mimeType: 'image/jpeg',
+            size: 64_000,
+            width: 320,
+            height: 180,
+        ));
+        $heroAsset->defineVariant(new AssetVariant(
+            name: 'mobile',
+            path: $heroAsset->getStoragePath() . '/variants/mobile/hero.jpg',
+            mimeType: 'image/jpeg',
+            size: 92_000,
+            width: 640,
+            height: 360,
+        ));
+
+        $logoAsset = new Asset(
+            workspace: $workspace,
+            fileName: 'logo.svg',
+            mimeType: 'image/svg+xml',
+            size: 4_096,
+            meta: ['title' => 'Основной логотип'],
+            id: 102,
+        );
+        $logoAsset->defineVariant(new AssetVariant(
+            name: 'white',
+            path: $logoAsset->getStoragePath() . '/variants/white/logo.svg',
+            mimeType: 'image/svg+xml',
+            size: 4_096,
+        ));
+
+        $galleryAttachment = new ElementAsset(
+            workspaceId: $workspace->getId() ?? 1,
+            elementId: 1,
+            assetId: $heroAsset->getId() ?? 101,
+            role: 'gallery',
+            position: 0,
+            variants: ['thumb', 'mobile'],
+            id: 1,
+        );
+        $galleryAttachment->attachAsset($heroAsset);
+
+        $brandingAttachment = new ElementAsset(
+            workspaceId: $workspace->getId() ?? 1,
+            elementId: 1,
+            assetId: $logoAsset->getId() ?? 102,
+            role: 'branding',
+            position: 0,
+            variants: ['white'],
+            id: 2,
+        );
+        $brandingAttachment->attachAsset($logoAsset);
+
+        $attachments = new ElementAssetCollection($galleryAttachment, $brandingAttachment);
+
         return $this->render('index', [
             'sampleTaxonomy' => $taxonomy,
             'taxonomyTree' => $taxonomyTree,
             'taxonomyLocale' => $locale,
+            'assets' => [$heroAsset, $logoAsset],
+            'assetAttachments' => $attachments,
         ]);
     }
 }

--- a/src/Http/Dashboard/Views/index/index.php
+++ b/src/Http/Dashboard/Views/index/index.php
@@ -1,5 +1,7 @@
 <?php
 
+use Setka\Cms\Domain\Assets\Asset;
+use Setka\Cms\Domain\Assets\ElementAssetCollection;
 use Setka\Cms\Domain\Taxonomy\Term;
 use yii\helpers\Html;
 
@@ -7,12 +9,85 @@ use yii\helpers\Html;
 /* @var \Setka\Cms\Domain\Taxonomy\Taxonomy|null $sampleTaxonomy */
 /* @var array<int, array{term: Term, children: array}> $taxonomyTree */
 /* @var string $taxonomyLocale */
+/* @var Asset[] $assets */
+/* @var ElementAssetCollection|null $assetAttachments */
 
 $this->title = 'Dashboard';
 ?>
 
 <h1><?= Html::encode($this->title) ?></h1>
 <p>Welcome to the Setka CMS dashboard.</p>
+
+<style>
+.media-library {
+    margin-top: 32px;
+}
+
+.media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.media-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 16px;
+    background: #ffffff;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.media-card h3 {
+    font-size: 16px;
+    margin-bottom: 8px;
+}
+
+.media-meta {
+    font-size: 13px;
+    color: #6b7280;
+    margin-bottom: 12px;
+}
+
+.variant-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 12px;
+    font-size: 13px;
+}
+
+.variant-list li {
+    display: flex;
+    justify-content: space-between;
+    padding: 2px 0;
+}
+
+.asset-attachments {
+    margin-top: 32px;
+}
+
+.asset-attachments table {
+    width: 100%;
+}
+
+.text-muted {
+    color: #6b7280;
+}
+</style>
+
+<?php
+$formatSize = static function (int $size): string {
+    if ($size >= 1_048_576) {
+        return number_format($size / 1_048_576, 1) . ' MB';
+    }
+
+    if ($size >= 1_024) {
+        return number_format($size / 1_024, 1) . ' KB';
+    }
+
+    return $size . ' B';
+};
+?>
 
 <?php if (!empty($taxonomyTree) && isset($sampleTaxonomy, $taxonomyLocale)): ?>
     <div class="taxonomy-preview">
@@ -42,6 +117,78 @@ $this->title = 'Dashboard';
 
         echo $renderTree($taxonomyTree);
         ?>
+    </div>
+<?php endif; ?>
+
+<?php if (!empty($assets ?? [])): ?>
+    <div class="media-library">
+        <h2>Медиа-библиотека</h2>
+        <div class="media-grid">
+            <?php foreach ($assets as $asset): ?>
+                <div class="media-card">
+                    <h3><?= Html::encode($asset->getFileName()) ?></h3>
+                    <p class="media-meta">
+                        <?= Html::encode($asset->getMimeType()) ?> · <?= Html::encode($formatSize($asset->getSize())) ?>
+                    </p>
+
+                    <?php $variants = $asset->getVariants(); ?>
+                    <?php if ($variants !== []): ?>
+                        <ul class="variant-list">
+                            <?php foreach ($variants as $variant): ?>
+                                <li>
+                                    <span><strong><?= Html::encode($variant->getName()) ?></strong></span>
+                                    <?php if ($variant->getWidth() !== null && $variant->getHeight() !== null): ?>
+                                        <span><?= Html::encode($variant->getWidth() . '×' . $variant->getHeight()) ?></span>
+                                    <?php else: ?>
+                                        <span class="text-muted"><?= Html::encode($formatSize($variant->getSize())) ?></span>
+                                    <?php endif; ?>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else: ?>
+                        <p class="text-muted">Варианты не заданы.</p>
+                    <?php endif; ?>
+
+                    <label>
+                        <input type="checkbox" checked>
+                        Добавить к элементу
+                    </label>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php if (isset($assetAttachments) && !$assetAttachments->isEmpty()): ?>
+    <div class="asset-attachments">
+        <h2>Привязанные медиа</h2>
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>Роль</th>
+                <th>Файл</th>
+                <th>Варианты</th>
+                <th class="text-muted">Позиция</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($assetAttachments as $attachment): ?>
+                <?php $attachmentAsset = $attachment->getAsset(); ?>
+                <tr>
+                    <td><?= Html::encode($attachment->getRole()) ?></td>
+                    <td>
+                        <?php if ($attachmentAsset !== null): ?>
+                            <?= Html::encode($attachmentAsset->getFileName()) ?>
+                        <?php else: ?>
+                            <?= Html::encode('ID ' . $attachment->getAssetId()) ?>
+                        <?php endif; ?>
+                    </td>
+                    <td><?= Html::encode(implode(', ', $attachment->getVariants())) ?></td>
+                    <td class="text-muted">#<?= Html::encode((string) $attachment->getPosition()) ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
     </div>
 <?php endif; ?>
 

--- a/src/Infrastructure/DBAL/Repositories/AssetRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/AssetRepository.php
@@ -1,0 +1,252 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\DBAL\Repositories;
+
+use DateTimeImmutable;
+use Exception;
+use InvalidArgumentException;
+use JsonException;
+use Setka\Cms\Contracts\Assets\AssetRepositoryInterface;
+use Setka\Cms\Domain\Assets\Asset;
+use Setka\Cms\Domain\Assets\AssetVariant;
+use Setka\Cms\Domain\Workspaces\Workspace;
+use yii\db\Connection;
+use yii\db\Query;
+use function is_array;
+use function is_numeric;
+use function json_decode;
+use function json_encode;
+use function time;
+
+final class AssetRepository implements AssetRepositoryInterface
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function findById(Workspace $workspace, int $id): ?Asset
+    {
+        $row = (new Query())
+            ->from('{{%asset}}')
+            ->where([
+                'id' => $id,
+                'workspace_id' => $this->requireWorkspaceId($workspace),
+            ])
+            ->one($this->db);
+
+        return $row ? $this->hydrate($workspace, $row) : null;
+    }
+
+    public function findByUid(Workspace $workspace, string $uid): ?Asset
+    {
+        $row = (new Query())
+            ->from('{{%asset}}')
+            ->where([
+                'uid' => $uid,
+                'workspace_id' => $this->requireWorkspaceId($workspace),
+            ])
+            ->one($this->db);
+
+        return $row ? $this->hydrate($workspace, $row) : null;
+    }
+
+    public function save(Asset $asset): void
+    {
+        $workspaceId = $this->requireWorkspaceId($asset->getWorkspace());
+        $now = time();
+
+        $data = [
+            'uid' => $asset->getUid(),
+            'workspace_id' => $workspaceId,
+            'file_name' => $asset->getFileName(),
+            'storage_path' => $asset->getStoragePath(),
+            'mime_type' => $asset->getMimeType(),
+            'size' => $asset->getSize(),
+            'meta' => $this->encodeMeta($asset->getMeta()),
+            'variants' => $this->encodeVariants($asset->getVariants()),
+            'updated_at' => $now,
+        ];
+
+        $id = $asset->getId();
+        if ($id === null) {
+            $data['created_at'] = $now;
+            $this->db->createCommand()
+                ->insert('{{%asset}}', $data)
+                ->execute();
+
+            $asset->defineId((int) $this->db->getLastInsertID());
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->update('{{%asset}}', $data, ['id' => $id])
+            ->execute();
+    }
+
+    public function delete(Asset $asset): void
+    {
+        $id = $asset->getId();
+        if ($id === null) {
+            return;
+        }
+
+        $this->db->createCommand()
+            ->delete('{{%asset}}', ['id' => $id])
+            ->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(Workspace $workspace, array $row): Asset
+    {
+        $meta = $this->decodeMeta($row['meta'] ?? null);
+        $variants = $this->decodeVariants($row['variants'] ?? null);
+
+        return new Asset(
+            workspace: $workspace,
+            fileName: (string) ($row['file_name'] ?? ''),
+            mimeType: (string) ($row['mime_type'] ?? ''),
+            size: isset($row['size']) ? (int) $row['size'] : 0,
+            storagePath: (string) ($row['storage_path'] ?? ''),
+            meta: $meta,
+            variants: $variants,
+            id: isset($row['id']) ? (int) $row['id'] : null,
+            uid: isset($row['uid']) ? (string) $row['uid'] : null,
+            createdAt: $this->createDateTime($row['created_at'] ?? null),
+            updatedAt: $this->createDateTime($row['updated_at'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeMeta(mixed $meta): array
+    {
+        if ($meta === null || $meta === '') {
+            return [];
+        }
+
+        if (is_array($meta)) {
+            return $meta;
+        }
+
+        try {
+            $decoded = json_decode((string) $meta, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    private function encodeMeta(array $meta): string
+    {
+        try {
+            return json_encode($meta, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return '{}';
+        }
+    }
+
+    /**
+     * @param AssetVariant[] $variants
+     */
+    private function encodeVariants(array $variants): string
+    {
+        $payload = [];
+        foreach ($variants as $variant) {
+            $payload[] = $variant->toArray();
+        }
+
+        try {
+            return json_encode($payload, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return '[]';
+        }
+    }
+
+    /**
+     * @return AssetVariant[]
+     */
+    private function decodeVariants(mixed $variants): array
+    {
+        if ($variants === null || $variants === '') {
+            return [];
+        }
+
+        $decoded = $variants;
+        if (!is_array($decoded)) {
+            try {
+                $decoded = json_decode((string) $variants, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                return [];
+            }
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($decoded as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            try {
+                $result[] = AssetVariant::fromArray($item);
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+        }
+
+        return $result;
+    }
+
+    private function createDateTime(mixed $timestamp): DateTimeImmutable
+    {
+        if ($timestamp instanceof DateTimeImmutable) {
+            return $timestamp;
+        }
+
+        $value = is_numeric($timestamp) ? (int) $timestamp : time();
+
+        try {
+            return (new DateTimeImmutable())->setTimestamp($value);
+        } catch (Exception) {
+            return new DateTimeImmutable();
+        }
+    }
+
+    private function requireWorkspaceId(Workspace $workspace): int
+    {
+        $workspaceId = $workspace->getId();
+        if ($workspaceId === null) {
+            throw new InvalidArgumentException('Workspace must have an identifier to work with assets.');
+        }
+
+        return $workspaceId;
+    }
+}

--- a/src/Infrastructure/DBAL/Repositories/ElementAssetRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/ElementAssetRepository.php
@@ -1,0 +1,206 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\DBAL\Repositories;
+
+use DateTimeImmutable;
+use Exception;
+use JsonException;
+use Setka\Cms\Contracts\Assets\ElementAssetRepositoryInterface;
+use Setka\Cms\Domain\Assets\ElementAsset;
+use Setka\Cms\Domain\Assets\ElementAssetCollection;
+use yii\db\Connection;
+use yii\db\Query;
+use function array_map;
+use function array_values;
+use function is_array;
+use function is_numeric;
+use function json_decode;
+use function json_encode;
+use function time;
+
+final class ElementAssetRepository implements ElementAssetRepositoryInterface
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function findByElement(int $workspaceId, int $elementId, ?string $role = null): ElementAssetCollection
+    {
+        $query = (new Query())
+            ->from('{{%element_asset}}')
+            ->where([
+                'workspace_id' => $workspaceId,
+                'element_id' => $elementId,
+            ])
+            ->orderBy(['role' => SORT_ASC, 'position' => SORT_ASC, 'id' => SORT_ASC]);
+
+        if ($role !== null && $role !== '') {
+            $query->andWhere(['role' => $role]);
+        }
+
+        $rows = $query->all($this->db);
+        $attachments = [];
+        foreach ($rows as $row) {
+            $attachments[] = $this->hydrate($row);
+        }
+
+        return new ElementAssetCollection(...$attachments);
+    }
+
+    public function findOne(int $workspaceId, int $elementId, int $assetId, string $role): ?ElementAsset
+    {
+        $row = (new Query())
+            ->from('{{%element_asset}}')
+            ->where([
+                'workspace_id' => $workspaceId,
+                'element_id' => $elementId,
+                'asset_id' => $assetId,
+                'role' => $role,
+            ])
+            ->one($this->db);
+
+        return $row ? $this->hydrate($row) : null;
+    }
+
+    public function save(ElementAsset $attachment): void
+    {
+        $now = time();
+        $data = [
+            'workspace_id' => $attachment->getWorkspaceId(),
+            'element_id' => $attachment->getElementId(),
+            'asset_id' => $attachment->getAssetId(),
+            'role' => $attachment->getRole(),
+            'position' => $attachment->getPosition(),
+            'variants' => $this->encodeVariants($attachment->getVariants()),
+            'updated_at' => $now,
+        ];
+
+        $id = $attachment->getId();
+        if ($id === null) {
+            $data['created_at'] = $now;
+            $this->db->createCommand()
+                ->insert('{{%element_asset}}', $data)
+                ->execute();
+
+            $attachment->defineId((int) $this->db->getLastInsertID());
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->update('{{%element_asset}}', $data, ['id' => $id])
+            ->execute();
+    }
+
+    public function delete(ElementAsset $attachment): void
+    {
+        $id = $attachment->getId();
+        if ($id !== null) {
+            $this->db->createCommand()
+                ->delete('{{%element_asset}}', ['id' => $id])
+                ->execute();
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->delete(
+                '{{%element_asset}}',
+                [
+                    'workspace_id' => $attachment->getWorkspaceId(),
+                    'element_id' => $attachment->getElementId(),
+                    'asset_id' => $attachment->getAssetId(),
+                    'role' => $attachment->getRole(),
+                ]
+            )
+            ->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): ElementAsset
+    {
+        return new ElementAsset(
+            workspaceId: isset($row['workspace_id']) ? (int) $row['workspace_id'] : 0,
+            elementId: isset($row['element_id']) ? (int) $row['element_id'] : 0,
+            assetId: isset($row['asset_id']) ? (int) $row['asset_id'] : 0,
+            role: (string) ($row['role'] ?? ''),
+            position: isset($row['position']) ? (int) $row['position'] : 0,
+            variants: $this->decodeVariants($row['variants'] ?? null),
+            id: isset($row['id']) ? (int) $row['id'] : null,
+            createdAt: $this->createDateTime($row['created_at'] ?? null),
+            updatedAt: $this->createDateTime($row['updated_at'] ?? null),
+        );
+    }
+
+    /**
+     * @param string[] $variants
+     */
+    private function encodeVariants(array $variants): string
+    {
+        try {
+            return json_encode($variants, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return '[]';
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function decodeVariants(mixed $variants): array
+    {
+        if ($variants === null || $variants === '') {
+            return [];
+        }
+
+        if (is_array($variants)) {
+            return array_values(array_map(static fn(mixed $value): string => (string) $value, $variants));
+        }
+
+        try {
+            $decoded = json_decode((string) $variants, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn(mixed $value): string => (string) $value, $decoded));
+    }
+
+    private function createDateTime(mixed $timestamp): DateTimeImmutable
+    {
+        if ($timestamp instanceof DateTimeImmutable) {
+            return $timestamp;
+        }
+
+        $value = is_numeric($timestamp) ? (int) $timestamp : time();
+
+        try {
+            return (new DateTimeImmutable())->setTimestamp($value);
+        } catch (Exception) {
+            return new DateTimeImmutable();
+        }
+    }
+}

--- a/src/Infrastructure/Storage/AssetStorage.php
+++ b/src/Infrastructure/Storage/AssetStorage.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelin. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelин <v.kamelин@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\Storage;
+
+use Setka\Cms\Contracts\Assets\AssetStorageInterface;
+
+final class AssetStorage implements AssetStorageInterface
+{
+    public function __construct(private readonly FlysystemStorage $storage)
+    {
+    }
+
+    public function write(string $path, string $contents): void
+    {
+        $this->storage->write($path, $contents);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->storage->read($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->storage->delete($path);
+    }
+}

--- a/tests/Unit/Domain/Assets/AssetServicesTest.php
+++ b/tests/Unit/Domain/Assets/AssetServicesTest.php
@@ -1,0 +1,210 @@
+<?php
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Assets;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Setka\Cms\Contracts\Assets\AssetStorageInterface;
+use Setka\Cms\Contracts\Assets\ElementAssetRepositoryInterface;
+use Setka\Cms\Domain\Assets\Asset;
+use Setka\Cms\Domain\Assets\AssetFileService;
+use Setka\Cms\Domain\Assets\AssetVariantService;
+use Setka\Cms\Domain\Assets\ElementAsset;
+use Setka\Cms\Domain\Assets\ElementAssetCollection;
+use Setka\Cms\Domain\Assets\ElementAssetService;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+final class AssetServicesTest extends TestCase
+{
+    public function testUploadAndReadAsset(): void
+    {
+        $storage = new InMemoryAssetStorage();
+        $fileService = new AssetFileService($storage);
+
+        $workspace = new Workspace('default', 'Default', ['en-US'], globalSettings: [], id: 1);
+        $asset = new Asset($workspace, 'example.png', 'image/png', id: 10);
+
+        $contents = "binary-data";
+        $fileService->store($asset, $contents);
+
+        self::assertSame(strlen($contents), $asset->getSize());
+        self::assertSame($contents, $fileService->read($asset));
+    }
+
+    public function testStoreVariantUpdatesAsset(): void
+    {
+        $storage = new InMemoryAssetStorage();
+        $variantService = new AssetVariantService($storage);
+
+        $workspace = new Workspace('default', 'Default', ['en-US'], globalSettings: [], id: 2);
+        $asset = new Asset($workspace, 'hero.jpg', 'image/jpeg', size: 128_000, id: 11);
+
+        $variant = $variantService->storeVariant(
+            $asset,
+            'thumb',
+            'thumb-data',
+            'image/jpeg',
+            ['width' => 320, 'height' => 180]
+        );
+
+        self::assertTrue($asset->hasVariant('thumb'));
+        self::assertSame(320, $variant->getWidth());
+        self::assertSame('thumb-data', $variantService->readVariant($asset, 'thumb'));
+
+        $variantService->deleteVariant($asset, 'thumb');
+        self::assertFalse($asset->hasVariant('thumb'));
+    }
+
+    public function testAttachAndListAssets(): void
+    {
+        $repository = new InMemoryElementAssetRepository();
+        $service = new ElementAssetService($repository);
+
+        $workspace = new Workspace('default', 'Default', ['en-US'], globalSettings: [], id: 3);
+        $heroAsset = new Asset($workspace, 'hero.jpg', 'image/jpeg', size: 256_000, id: 21);
+        $galleryAsset = new Asset($workspace, 'gallery.jpg', 'image/jpeg', size: 512_000, id: 22);
+
+        $first = $service->attach($workspace, $heroAsset, 42, 'gallery', ['thumb']);
+        self::assertSame(0, $first->getPosition());
+        self::assertSame(['thumb'], $first->getVariants());
+
+        $second = $service->attach($workspace, $galleryAsset, 42, 'gallery');
+        self::assertSame(1, $second->getPosition());
+
+        $list = $service->list($workspace, 42, 'gallery');
+        self::assertCount(2, $list);
+
+        $items = iterator_to_array($list);
+        self::assertSame($heroAsset->getId(), $items[0]->getAssetId());
+        self::assertSame($galleryAsset->getId(), $items[1]->getAssetId());
+
+        $service->reorder($workspace, 42, 'gallery', [$galleryAsset->getId(), $heroAsset->getId()]);
+        $ordered = iterator_to_array($service->list($workspace, 42, 'gallery'));
+        self::assertSame($galleryAsset->getId(), $ordered[0]->getAssetId());
+        self::assertSame(0, $ordered[0]->getPosition());
+        self::assertSame(1, $ordered[1]->getPosition());
+
+        $service->detach($workspace, $galleryAsset, 42, 'gallery');
+        $remaining = iterator_to_array($service->list($workspace, 42, 'gallery'));
+        self::assertCount(1, $remaining);
+        self::assertSame($heroAsset->getId(), $remaining[0]->getAssetId());
+        self::assertSame(0, $remaining[0]->getPosition());
+    }
+}
+
+/**
+ * Простая in-memory реализация файлового хранилища для тестов.
+ */
+final class InMemoryAssetStorage implements AssetStorageInterface
+{
+    /** @var array<string, string> */
+    private array $files = [];
+
+    public function write(string $path, string $contents): void
+    {
+        $this->files[$path] = $contents;
+    }
+
+    public function read(string $path): string
+    {
+        if (!isset($this->files[$path])) {
+            throw new RuntimeException('File not found: ' . $path);
+        }
+
+        return $this->files[$path];
+    }
+
+    public function delete(string $path): void
+    {
+        unset($this->files[$path]);
+    }
+}
+
+/**
+ * In-memory репозиторий привязок медиа к элементам для тестов.
+ */
+final class InMemoryElementAssetRepository implements ElementAssetRepositoryInterface
+{
+    /** @var array<int, ElementAsset> */
+    private array $items = [];
+
+    private int $autoIncrement = 1;
+
+    public function findByElement(int $workspaceId, int $elementId, ?string $role = null): ElementAssetCollection
+    {
+        $matches = [];
+        foreach ($this->items as $item) {
+            if ($item->getWorkspaceId() !== $workspaceId) {
+                continue;
+            }
+
+            if ($item->getElementId() !== $elementId) {
+                continue;
+            }
+
+            if ($role !== null && $role !== '' && $item->getRole() !== $role) {
+                continue;
+            }
+
+            $matches[] = clone $item;
+        }
+
+        return new ElementAssetCollection(...$matches);
+    }
+
+    public function findOne(int $workspaceId, int $elementId, int $assetId, string $role): ?ElementAsset
+    {
+        foreach ($this->items as $item) {
+            if ($item->getWorkspaceId() !== $workspaceId) {
+                continue;
+            }
+
+            if ($item->getElementId() !== $elementId) {
+                continue;
+            }
+
+            if ($item->getAssetId() !== $assetId) {
+                continue;
+            }
+
+            if ($item->getRole() !== $role) {
+                continue;
+            }
+
+            return clone $item;
+        }
+
+        return null;
+    }
+
+    public function save(ElementAsset $attachment): void
+    {
+        if ($attachment->getId() === null) {
+            $attachment->defineId($this->autoIncrement++);
+        }
+
+        $this->items[$attachment->getId()] = clone $attachment;
+    }
+
+    public function delete(ElementAsset $attachment): void
+    {
+        $id = $attachment->getId();
+        if ($id !== null) {
+            unset($this->items[$id]);
+
+            return;
+        }
+
+        foreach ($this->items as $key => $item) {
+            if (
+                $item->getWorkspaceId() === $attachment->getWorkspaceId()
+                && $item->getElementId() === $attachment->getElementId()
+                && $item->getAssetId() === $attachment->getAssetId()
+                && $item->getRole() === $attachment->getRole()
+            ) {
+                unset($this->items[$key]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- добавлены доменные сущности для медиа-активов, сервисы работы с файлами и вариантами, репозитории и миграция таблиц
- интегрирована файловая подсистема с контейнером, обновлены контроллер и представление дашборда для отображения библиотеки медиа
- добавлены модульные тесты, покрывающие загрузку файлов, регистрацию вариантов и привязку активов к элементам

## Testing
- `composer test` *(не выполнено: требуются зависимости с GitHub, установка прервана из-за 403)*

------
https://chatgpt.com/codex/tasks/task_e_68caaa45bb44832d9fd5586dc11e9dd2