### PR TITLE
Add tree hierarchy support for elements

### DIFF
--- a/migrations/m250922_110000_extend_element_tree.php
+++ b/migrations/m250922_110000_extend_element_tree.php
@@ -1,0 +1,154 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * Copyright (c) 2025 Vitaliy Kamelин. All rights reserved.
+ * Proprietary license. Unauthorized copying, modification or distribution
+ * of this file, via any medium, is strictly prohibited without prior written permission.
+ *
+ * @package   Setka CMS
+ * @version   1.0.0
+ * @author    Vitaliy Kamelin <v.kamelin@gmail.com>
+ * @license   Proprietary
+ *
+ * https://github.com/setkacms/cms
+ * See LICENSE file for details.
+ */
+
+declare(strict_types=1);
+
+use yii\db\Migration;
+
+/**
+ * Добавляет поддержку иерархии для таблицы element.
+ */
+final class m250922_110000_extend_element_tree extends Migration
+{
+    public function safeUp(): void
+    {
+        $schema = $this->db->getSchema();
+        $table = $schema->getTableSchema('{{%element}}', true);
+        if ($table === null) {
+            return;
+        }
+
+        if ($table->getColumn('parent_id') === null) {
+            $this->addColumn('{{%element}}', 'parent_id', $this->integer()->null());
+        }
+
+        if ($table->getColumn('position') === null) {
+            $this->addColumn('{{%element}}', 'position', $this->integer()->notNull()->defaultValue(0));
+            $this->update('{{%element}}', ['position' => 0], ['position' => null]);
+        }
+
+        if ($table->getColumn('lft') === null) {
+            $this->addColumn('{{%element}}', 'lft', $this->integer()->null());
+        }
+
+        if ($table->getColumn('rgt') === null) {
+            $this->addColumn('{{%element}}', 'rgt', $this->integer()->null());
+        }
+
+        if ($table->getColumn('depth') === null) {
+            $this->addColumn('{{%element}}', 'depth', $this->integer()->null());
+        }
+
+        $indexes = $schema->getTableIndexes('{{%element}}');
+        $indexNames = [];
+        foreach ($indexes as $index) {
+            $indexNames[] = $index->name;
+        }
+
+        if (!in_array('idx_element_parent', $indexNames, true)) {
+            $this->createIndex('idx_element_parent', '{{%element}}', 'parent_id');
+        }
+
+        if (!in_array('idx_element_parent_position', $indexNames, true)) {
+            $this->createIndex('idx_element_parent_position', '{{%element}}', ['parent_id', 'position']);
+        }
+
+        if (!in_array('idx_element_lft_rgt', $indexNames, true)) {
+            $this->createIndex('idx_element_lft_rgt', '{{%element}}', ['lft', 'rgt']);
+        }
+
+        if (!in_array('idx_element_depth', $indexNames, true)) {
+            $this->createIndex('idx_element_depth', '{{%element}}', 'depth');
+        }
+
+        $foreignKeys = $schema->getTableForeignKeys('{{%element}}');
+        $hasParentFk = false;
+        foreach ($foreignKeys as $foreignKey) {
+            if ($foreignKey->name === 'fk_element_parent') {
+                $hasParentFk = true;
+                break;
+            }
+        }
+
+        if (!$hasParentFk) {
+            $this->addForeignKey(
+                'fk_element_parent',
+                '{{%element}}',
+                'parent_id',
+                '{{%element}}',
+                'id',
+                'SET NULL',
+                'CASCADE'
+            );
+        }
+    }
+
+    public function safeDown(): void
+    {
+        $schema = $this->db->getSchema();
+        $table = $schema->getTableSchema('{{%element}}', true);
+        if ($table === null) {
+            return;
+        }
+
+        $foreignKeys = $schema->getTableForeignKeys('{{%element}}');
+        foreach ($foreignKeys as $foreignKey) {
+            if ($foreignKey->name === 'fk_element_parent') {
+                $this->dropForeignKey('fk_element_parent', '{{%element}}');
+                break;
+            }
+        }
+
+        $indexes = $schema->getTableIndexes('{{%element}}');
+        foreach ($indexes as $index) {
+            switch ($index->name) {
+                case 'idx_element_parent':
+                    $this->dropIndex('idx_element_parent', '{{%element}}');
+                    break;
+                case 'idx_element_parent_position':
+                    $this->dropIndex('idx_element_parent_position', '{{%element}}');
+                    break;
+                case 'idx_element_lft_rgt':
+                    $this->dropIndex('idx_element_lft_rgt', '{{%element}}');
+                    break;
+                case 'idx_element_depth':
+                    $this->dropIndex('idx_element_depth', '{{%element}}');
+                    break;
+            }
+        }
+
+        if ($table->getColumn('depth') !== null) {
+            $this->dropColumn('{{%element}}', 'depth');
+        }
+
+        if ($table->getColumn('rgt') !== null) {
+            $this->dropColumn('{{%element}}', 'rgt');
+        }
+
+        if ($table->getColumn('lft') !== null) {
+            $this->dropColumn('{{%element}}', 'lft');
+        }
+
+        if ($table->getColumn('position') !== null) {
+            $this->dropColumn('{{%element}}', 'position');
+        }
+
+        if ($table->getColumn('parent_id') !== null) {
+            $this->dropColumn('{{%element}}', 'parent_id');
+        }
+    }
+}

--- a/src/Contracts/Elements/ElementInterface.php
+++ b/src/Contracts/Elements/ElementInterface.php
@@ -31,6 +31,18 @@ interface ElementInterface
 
     public function getTitle(): string;
 
+    public function getParentId(): ?int;
+
+    public function getPosition(): int;
+
+    public function getLeftBoundary(): ?int;
+
+    public function getRightBoundary(): ?int;
+
+    public function getDepth(): ?int;
+
+    public function getParent(): ?ElementInterface;
+
     public function getLocale(): string;
 
     public function getSchemaId(): ?int;

--- a/src/Infrastructure/DBAL/Repositories/ElementRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/ElementRepository.php
@@ -120,6 +120,11 @@ final class ElementRepository implements ElementRepositoryInterface
             schemaId: isset($row['element_schema_id']) ? (int) $row['element_schema_id'] : null,
             publicationPlan: $publicationPlan,
             status: $status,
+            parentId: isset($row['element_parent_id']) ? (int) $row['element_parent_id'] : null,
+            position: isset($row['element_position']) ? (int) $row['element_position'] : 0,
+            leftBoundary: isset($row['element_lft']) ? (int) $row['element_lft'] : null,
+            rightBoundary: isset($row['element_rgt']) ? (int) $row['element_rgt'] : null,
+            depth: isset($row['element_depth']) ? (int) $row['element_depth'] : null,
         );
 
         $locale = (string) $row['element_locale'];
@@ -146,6 +151,11 @@ final class ElementRepository implements ElementRepositoryInterface
                 'element_status' => 'e.status',
                 'element_publication_plan' => 'e.publication_plan',
                 'element_schema_id' => 'e.schema_id',
+                'element_parent_id' => 'e.parent_id',
+                'element_position' => 'e.position',
+                'element_lft' => 'e.lft',
+                'element_rgt' => 'e.rgt',
+                'element_depth' => 'e.depth',
                 'collection_id' => 'c.id',
                 'collection_uid' => 'c.uid',
                 'collection_handle' => 'c.handle',


### PR DESCRIPTION
## Summary
- add a migration that equips the element table with parent, position and nested-set columns plus supporting indexes and a self-referencing foreign key
- extend the Element domain model and contract with parent/position accessors, validation helpers and tree metric management
- load the new tree metadata inside the DB repository and cover tree scenarios with unit tests

## Testing
- ⚠️ `composer install --no-interaction` *(fails: CONNECT tunnel 403 while downloading GitHub sources, so PHPUnit dependencies are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb2305a84832dba0bf96199609f4e