### PR TITLE
feat: scaffold dashboard sections

### DIFF
--- a/src/Http/Dashboard/Controllers/CollectionsController.php
+++ b/src/Http/Dashboard/Controllers/CollectionsController.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class CollectionsController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionCreate(): string
+    {
+        return $this->render('create');
+    }
+}

--- a/src/Http/Dashboard/Controllers/ElementsController.php
+++ b/src/Http/Dashboard/Controllers/ElementsController.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class ElementsController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionCreate(): string
+    {
+        return $this->render('create');
+    }
+
+    public function actionDrafts(): string
+    {
+        return $this->render('drafts');
+    }
+
+    public function actionTrash(): string
+    {
+        return $this->render('trash');
+    }
+}

--- a/src/Http/Dashboard/Controllers/FieldsController.php
+++ b/src/Http/Dashboard/Controllers/FieldsController.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class FieldsController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionGroups(): string
+    {
+        return $this->render('groups');
+    }
+}

--- a/src/Http/Dashboard/Controllers/IntegrationsController.php
+++ b/src/Http/Dashboard/Controllers/IntegrationsController.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class IntegrationsController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionRest(): string
+    {
+        return $this->render('rest');
+    }
+
+    public function actionGraphql(): string
+    {
+        return $this->render('graphql');
+    }
+
+    public function actionWebhooks(): string
+    {
+        return $this->render('webhooks');
+    }
+}

--- a/src/Http/Dashboard/Controllers/LocalizationController.php
+++ b/src/Http/Dashboard/Controllers/LocalizationController.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class LocalizationController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionLanguages(): string
+    {
+        return $this->render('languages');
+    }
+
+    public function actionTranslations(): string
+    {
+        return $this->render('translations');
+    }
+}

--- a/src/Http/Dashboard/Controllers/MediaController.php
+++ b/src/Http/Dashboard/Controllers/MediaController.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class MediaController extends Controller
+{
+    public function actionLibrary(): string
+    {
+        return $this->render('library');
+    }
+
+    public function actionUpload(): string
+    {
+        return $this->render('upload');
+    }
+}

--- a/src/Http/Dashboard/Controllers/PluginsController.php
+++ b/src/Http/Dashboard/Controllers/PluginsController.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class PluginsController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionInstall(): string
+    {
+        return $this->render('install');
+    }
+
+    public function actionUpdates(): string
+    {
+        return $this->render('updates');
+    }
+}

--- a/src/Http/Dashboard/Controllers/RelationsController.php
+++ b/src/Http/Dashboard/Controllers/RelationsController.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class RelationsController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+}

--- a/src/Http/Dashboard/Controllers/RolesController.php
+++ b/src/Http/Dashboard/Controllers/RolesController.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class RolesController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+}

--- a/src/Http/Dashboard/Controllers/SchemasController.php
+++ b/src/Http/Dashboard/Controllers/SchemasController.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class SchemasController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+}

--- a/src/Http/Dashboard/Controllers/SearchController.php
+++ b/src/Http/Dashboard/Controllers/SearchController.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class SearchController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+}

--- a/src/Http/Dashboard/Controllers/SettingsController.php
+++ b/src/Http/Dashboard/Controllers/SettingsController.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class SettingsController extends Controller
+{
+    public function actionGeneral(): string
+    {
+        return $this->render('general');
+    }
+
+    public function actionSecurity(): string
+    {
+        return $this->render('security');
+    }
+
+    public function actionStorage(): string
+    {
+        return $this->render('storage');
+    }
+}

--- a/src/Http/Dashboard/Controllers/SystemController.php
+++ b/src/Http/Dashboard/Controllers/SystemController.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class SystemController extends Controller
+{
+    public function actionLogs(): string
+    {
+        return $this->render('logs');
+    }
+
+    public function actionQueue(): string
+    {
+        return $this->render('queue');
+    }
+
+    public function actionJobs(): string
+    {
+        return $this->render('jobs');
+    }
+}

--- a/src/Http/Dashboard/Controllers/TaxonomiesController.php
+++ b/src/Http/Dashboard/Controllers/TaxonomiesController.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class TaxonomiesController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionTerms(): string
+    {
+        return $this->render('terms');
+    }
+}

--- a/src/Http/Dashboard/Controllers/UsersController.php
+++ b/src/Http/Dashboard/Controllers/UsersController.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class UsersController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionInvite(): string
+    {
+        return $this->render('invite');
+    }
+}

--- a/src/Http/Dashboard/Controllers/WorkflowController.php
+++ b/src/Http/Dashboard/Controllers/WorkflowController.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class WorkflowController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionStates(): string
+    {
+        return $this->render('states');
+    }
+
+    public function actionTransitions(): string
+    {
+        return $this->render('transitions');
+    }
+}

--- a/src/Http/Dashboard/Controllers/WorkspacesController.php
+++ b/src/Http/Dashboard/Controllers/WorkspacesController.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Http\Dashboard\Controllers;
+
+use yii\web\Controller;
+
+final class WorkspacesController extends Controller
+{
+    public function actionIndex(): string
+    {
+        return $this->render('index');
+    }
+
+    public function actionCreate(): string
+    {
+        return $this->render('create');
+    }
+}

--- a/src/Http/Dashboard/Module.php
+++ b/src/Http/Dashboard/Module.php
@@ -12,6 +12,7 @@ use Setka\Cms\Domain\Dashboard\ActivityRepositoryInterface;
 use Setka\Cms\Domain\Dashboard\MetricsRepositoryInterface;
 use Setka\Cms\Domain\Dashboard\QuickActionRepositoryInterface;
 use Setka\Cms\Domain\Dashboard\WarningRepositoryInterface;
+use Setka\Cms\Http\Dashboard\Controllers as DashboardControllers;
 use Setka\Cms\Infrastructure\Dashboard\InMemoryActivityRepository;
 use Setka\Cms\Infrastructure\Dashboard\InMemoryMetricsRepository;
 use Setka\Cms\Infrastructure\Dashboard\InMemoryQuickActionRepository;
@@ -37,6 +38,32 @@ class Module extends BaseModule
         $this->setViewPath($viewPath);
         $this->setLayoutPath($viewPath . DIRECTORY_SEPARATOR . 'layouts');
         $this->layout = 'main';
+
+        $this->controllerMap = array_merge(
+            [
+                'index' => ['class' => DashboardControllers\IndexController::class],
+                'collections' => ['class' => DashboardControllers\CollectionsController::class],
+                'elements' => ['class' => DashboardControllers\ElementsController::class],
+                'media' => ['class' => DashboardControllers\MediaController::class],
+                'assets' => ['class' => DashboardControllers\MediaController::class],
+                'schemas' => ['class' => DashboardControllers\SchemasController::class],
+                'fields' => ['class' => DashboardControllers\FieldsController::class],
+                'taxonomies' => ['class' => DashboardControllers\TaxonomiesController::class],
+                'taxonomy' => ['class' => DashboardControllers\TaxonomiesController::class],
+                'relations' => ['class' => DashboardControllers\RelationsController::class],
+                'users' => ['class' => DashboardControllers\UsersController::class],
+                'roles' => ['class' => DashboardControllers\RolesController::class],
+                'workspaces' => ['class' => DashboardControllers\WorkspacesController::class],
+                'plugins' => ['class' => DashboardControllers\PluginsController::class],
+                'integrations' => ['class' => DashboardControllers\IntegrationsController::class],
+                'settings' => ['class' => DashboardControllers\SettingsController::class],
+                'system' => ['class' => DashboardControllers\SystemController::class],
+                'search' => ['class' => DashboardControllers\SearchController::class],
+                'localization' => ['class' => DashboardControllers\LocalizationController::class],
+                'workflow' => ['class' => DashboardControllers\WorkflowController::class],
+            ],
+            $this->controllerMap
+        );
 
         $container = Yii::$container;
         $container->set(MetricsRepositoryInterface::class, InMemoryMetricsRepository::class);

--- a/src/Http/Dashboard/Views/collections/create.php
+++ b/src/Http/Dashboard/Views/collections/create.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Новая коллекция';
+$this->params['breadcrumbs'][] = ['label' => 'Коллекции', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-success" data-role="collection-form-wrapper">
+    <div class="box-header with-border">
+        <h3 class="box-title">Создание коллекции</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-default" data-action="show-help">
+                    <i class="fa fa-question-circle"></i> Помощь
+                </button>
+                <button type="button" class="btn btn-default" data-action="preview-collection">
+                    <i class="fa fa-eye"></i> Предпросмотр
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <form class="form-horizontal" data-role="collection-form">
+            <div class="form-group">
+                <label for="collection-title" class="col-sm-3 control-label">Название</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="collection-title" placeholder="Например: Новости">
+                    <p class="help-block">Отображается в навигации и списках.</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="collection-slug" class="col-sm-3 control-label">Символьный код</label>
+                <div class="col-sm-9">
+                    <div class="input-group">
+                        <span class="input-group-addon">/</span>
+                        <input type="text" class="form-control" id="collection-slug" placeholder="news">
+                    </div>
+                    <p class="help-block">Используется для формирования URL и API-эндпоинтов.</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label" for="collection-description">Описание</label>
+                <div class="col-sm-9">
+                    <textarea class="form-control" rows="4" id="collection-description" placeholder="Краткое описание назначения коллекции"></textarea>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label" for="collection-workflow">Воркфлоу</label>
+                <div class="col-sm-9">
+                    <select id="collection-workflow" class="form-control select2">
+                        <option value="">Стандартный</option>
+                        <option value="editorial">Редакционный</option>
+                        <option value="review">С ревью</option>
+                    </select>
+                    <p class="help-block">Определяет цепочку согласования элементов.</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Права доступа</label>
+                <div class="col-sm-9">
+                    <div class="checkbox">
+                        <label><input type="checkbox" checked> Разрешить авторам создание элементов</label>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" checked> Разрешить редакторам публикацию</label>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox"> Включить публичную страницу коллекции</label>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left">
+            <?= Html::a('<i class="fa fa-angle-left"></i> Назад к списку', ['index'], [
+                'class' => 'btn btn-default btn-sm',
+                'data-pjax' => '0',
+            ]) ?>
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-default" data-action="save-draft">Сохранить черновик</button>
+            <button type="button" class="btn btn-success" data-action="save-collection">
+                <i class="fa fa-check"></i> Создать коллекцию
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="collection-help" tabindex="-1" role="dialog" aria-labelledby="collection-help-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="collection-help-label">О коллекциях</h4>
+            </div>
+            <div class="modal-body">
+                <p>Коллекции группируют элементы по смыслу и позволяют определять отдельные наборы полей, правила публикации и воркфлоу. После внедрения backend данная подсказка будет заменена справкой.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary btn-sm" data-dismiss="modal">Понятно</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/collections/index.php
+++ b/src/Http/Dashboard/Views/collections/index.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Коллекции';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary">
+    <div class="box-header with-border">
+        <h3 class="box-title">Список коллекций</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <?= Html::a('<i class="fa fa-plus"></i> Новая коллекция', ['create'], [
+                    'class' => 'btn btn-success',
+                    'data-pjax' => '0',
+                ]) ?>
+                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#collections-import">
+                    <i class="fa fa-upload"></i> Импорт
+                </button>
+                <button type="button" class="btn btn-default" data-action="export-collections">
+                    <i class="fa fa-download"></i> Экспорт
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="row margin-bottom">
+            <div class="col-sm-8">
+                <form class="form-inline" role="search" data-role="collections-filters">
+                    <div class="form-group">
+                        <label class="sr-only" for="collections-search">Поиск</label>
+                        <input type="search" class="form-control input-sm" id="collections-search" placeholder="Поиск по названию">
+                    </div>
+                    <div class="form-group">
+                        <label class="sr-only" for="collections-status">Статус</label>
+                        <select id="collections-status" class="form-control input-sm select2" style="min-width: 160px;">
+                            <option value="">Все статусы</option>
+                            <option value="published">Опубликовано</option>
+                            <option value="draft">Черновик</option>
+                            <option value="archived">Архив</option>
+                        </select>
+                    </div>
+                    <button type="button" class="btn btn-default btn-sm" data-action="reset-filters">
+                        <i class="fa fa-times"></i>
+                    </button>
+                </form>
+            </div>
+            <div class="col-sm-4 text-right">
+                <div class="btn-group btn-group-sm">
+                    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#collections-columns">
+                        <i class="fa fa-table"></i> Колонки
+                    </button>
+                    <button type="button" class="btn btn-default" data-action="save-view">
+                        <i class="fa fa-bookmark"></i> Сохранить вид
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover" data-role="collections-table">
+                <thead>
+                <tr>
+                    <th class="text-center" style="width: 40px;">
+                        <input type="checkbox" data-role="select-all">
+                    </th>
+                    <th>Название</th>
+                    <th class="hidden-xs">Слаг</th>
+                    <th class="hidden-xs">Элементов</th>
+                    <th class="hidden-xs" style="width: 160px;">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="5" class="text-center text-muted">Данные появятся после подключения хранилища.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left">
+            <select class="form-control input-sm" data-role="collections-bulk" style="width: 220px;">
+                <option value="">Массовое действие</option>
+                <option value="publish">Опубликовать</option>
+                <option value="archive">Переместить в архив</option>
+                <option value="delete">Удалить</option>
+            </select>
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-primary btn-sm" data-action="bulk-apply">
+                <i class="fa fa-play"></i> Применить
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="collections-import" tabindex="-1" role="dialog" aria-labelledby="collections-import-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="collections-import-label">Импорт коллекций</h4>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted">Здесь будет форма импорта из CSV/JSON. Добавьте файл, чтобы загрузить коллекции массово.</p>
+                <div class="form-group">
+                    <label class="control-label">Файл импорта</label>
+                    <input type="file" class="form-control" data-role="collections-import-file">
+                </div>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" checked> Обновлять существующие записи
+                    </label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="start-import">Запустить импорт</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="collections-columns" tabindex="-1" role="dialog" aria-labelledby="collections-columns-label">
+    <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="collections-columns-label">Настройка колонок</h4>
+            </div>
+            <div class="modal-body">
+                <div class="checkbox">
+                    <label><input type="checkbox" checked> Слаг</label>
+                </div>
+                <div class="checkbox">
+                    <label><input type="checkbox" checked> Элементов</label>
+                </div>
+                <div class="checkbox">
+                    <label><input type="checkbox" checked> Обновлено</label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary btn-sm" data-dismiss="modal">Готово</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/elements/create.php
+++ b/src/Http/Dashboard/Views/elements/create.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Создание элемента';
+$this->params['breadcrumbs'][] = ['label' => 'Элементы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-success" data-role="element-form">
+    <div class="box-header with-border">
+        <h3 class="box-title">Новый элемент</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-default" data-action="toggle-preview">
+                    <i class="fa fa-eye"></i> Предпросмотр
+                </button>
+                <button type="button" class="btn btn-default" data-action="open-history">
+                    <i class="fa fa-history"></i> История
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="row">
+            <div class="col-md-8">
+                <div class="form-group">
+                    <label for="element-title">Заголовок</label>
+                    <input type="text" id="element-title" class="form-control" placeholder="Введите заголовок">
+                </div>
+                <div class="form-group">
+                    <label for="element-slug">Символьный код</label>
+                    <input type="text" id="element-slug" class="form-control" placeholder="Будет сгенерирован автоматически">
+                </div>
+                <div class="form-group">
+                    <label for="element-content">Содержимое</label>
+                    <textarea id="element-content" class="form-control" rows="12" placeholder="Тело материала, поддерживается Markdown/HTML"></textarea>
+                    <p class="help-block">Позже здесь появится WYSIWYG-редактор.</p>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="box box-solid">
+                    <div class="box-header with-border">
+                        <h4 class="box-title">Параметры</h4>
+                    </div>
+                    <div class="box-body">
+                        <div class="form-group">
+                            <label for="element-collection">Коллекция</label>
+                            <select id="element-collection" class="form-control select2">
+                                <option value="news">Новости</option>
+                                <option value="blog">Блог</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="element-status">Статус</label>
+                            <select id="element-status" class="form-control">
+                                <option value="draft">Черновик</option>
+                                <option value="review">На ревью</option>
+                                <option value="published">Опубликовано</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="element-tags">Теги</label>
+                            <input type="text" id="element-tags" class="form-control" placeholder="Введите теги через запятую">
+                        </div>
+                        <div class="checkbox">
+                            <label><input type="checkbox" checked> Разрешить комментарии</label>
+                        </div>
+                        <div class="checkbox">
+                            <label><input type="checkbox"> Закрепить в коллекции</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="box box-solid">
+                    <div class="box-header with-border">
+                        <h4 class="box-title">Медиа</h4>
+                        <div class="box-tools">
+                            <button type="button" class="btn btn-box-tool" data-action="attach-media"><i class="fa fa-plus"></i></button>
+                        </div>
+                    </div>
+                    <div class="box-body text-muted small">
+                        Подключите изображения и документы из медиатеки.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left">
+            <?= Html::a('<i class="fa fa-angle-left"></i> К списку', ['index'], [
+                'class' => 'btn btn-default btn-sm',
+                'data-pjax' => '0',
+            ]) ?>
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-default" data-action="save-draft">Сохранить черновик</button>
+            <button type="button" class="btn btn-primary" data-action="send-review">На ревью</button>
+            <button type="button" class="btn btn-success" data-action="publish-element">
+                <i class="fa fa-check"></i> Опубликовать
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="element-history" tabindex="-1" role="dialog" aria-labelledby="element-history-label">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="element-history-label">История изменений</h4>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted">Журнал версий будет доступен после интеграции с backend.</p>
+                <table class="table table-condensed">
+                    <thead>
+                    <tr>
+                        <th>Дата</th>
+                        <th>Автор</th>
+                        <th>Комментарий</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td colspan="3" class="text-center text-muted">Записей пока нет.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/elements/drafts.php
+++ b/src/Http/Dashboard/Views/elements/drafts.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Черновики элементов';
+$this->params['breadcrumbs'][] = ['label' => 'Элементы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-warning">
+    <div class="box-header with-border">
+        <h3 class="box-title">Черновики</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-default" data-action="bulk-assign">
+                    <i class="fa fa-user"></i> Назначить редактора
+                </button>
+                <button type="button" class="btn btn-default" data-action="bulk-submit">
+                    <i class="fa fa-paper-plane"></i> Отправить на ревью
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="drafts-table">
+                <thead>
+                <tr>
+                    <th style="width: 40px;" class="text-center"><input type="checkbox" data-role="select-all"></th>
+                    <th>Заголовок</th>
+                    <th class="hidden-xs">Автор</th>
+                    <th class="hidden-xs">Коллекция</th>
+                    <th class="hidden-xs" style="width: 150px;">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="5" class="text-muted text-center">Черновики появятся после создания элементов.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left text-muted small">
+            Управляйте черновиками перед отправкой в публикацию.
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-primary btn-sm" data-action="review-selected">
+                <i class="fa fa-check"></i> Отправить на ревью
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/elements/index.php
+++ b/src/Http/Dashboard/Views/elements/index.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Элементы';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="elements-list">
+    <div class="box-header with-border">
+        <h3 class="box-title">Все элементы</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <?= Html::a('<i class="fa fa-plus"></i> Создать элемент', ['/dashboard/elements/create'], [
+                    'class' => 'btn btn-success',
+                    'data-pjax' => '0',
+                ]) ?>
+                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#elements-filters">
+                    <i class="fa fa-filter"></i> Фильтры
+                </button>
+                <button type="button" class="btn btn-default" data-action="elements-refresh">
+                    <i class="fa fa-refresh"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped table-hover" data-role="elements-table">
+                <thead>
+                <tr>
+                    <th style="width: 40px;" class="text-center"><input type="checkbox" data-role="select-all"></th>
+                    <th>Заголовок</th>
+                    <th class="hidden-xs">Коллекция</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th class="hidden-xs" style="width: 150px;">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="5" class="text-muted text-center">Записи появятся после настройки источника данных.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left">
+            <div class="form-inline">
+                <div class="form-group">
+                    <label class="sr-only" for="elements-bulk">Действие</label>
+                    <select class="form-control input-sm" id="elements-bulk" data-role="elements-bulk-action">
+                        <option value="">Массовое действие</option>
+                        <option value="publish">Опубликовать</option>
+                        <option value="archive">В архив</option>
+                        <option value="delete">Удалить</option>
+                    </select>
+                </div>
+                <button type="button" class="btn btn-primary btn-sm" data-action="apply-bulk">
+                    <i class="fa fa-play"></i>
+                </button>
+            </div>
+        </div>
+        <div class="pull-right text-muted small">
+            <span data-role="elements-counter">0</span> элементов отображается.
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="elements-filters" tabindex="-1" role="dialog" aria-labelledby="elements-filters-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="elements-filters-label">Фильтр элементов</h4>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="filter-collection" class="control-label">Коллекция</label>
+                    <select id="filter-collection" class="form-control select2" data-placeholder="Все коллекции">
+                        <option value=""></option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="filter-author" class="control-label">Автор</label>
+                    <input type="text" class="form-control" id="filter-author" placeholder="Начните вводить имя">
+                </div>
+                <div class="form-group">
+                    <label class="control-label">Дата публикации</label>
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <input type="date" class="form-control" data-role="filter-date-from">
+                        </div>
+                        <div class="col-xs-6">
+                            <input type="date" class="form-control" data-role="filter-date-to">
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+                <button type="button" class="btn btn-primary" data-action="apply-filters">Применить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/elements/trash.php
+++ b/src/Http/Dashboard/Views/elements/trash.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Корзина элементов';
+$this->params['breadcrumbs'][] = ['label' => 'Элементы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-danger">
+    <div class="box-header with-border">
+        <h3 class="box-title">Удалённые элементы</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-default" data-action="restore-selected">
+                    <i class="fa fa-undo"></i> Восстановить
+                </button>
+                <button type="button" class="btn btn-default" data-action="purge-selected">
+                    <i class="fa fa-trash"></i> Удалить навсегда
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="trash-table">
+                <thead>
+                <tr>
+                    <th style="width: 40px;" class="text-center"><input type="checkbox" data-role="select-all"></th>
+                    <th>Заголовок</th>
+                    <th class="hidden-xs">Коллекция</th>
+                    <th class="hidden-xs">Удалил</th>
+                    <th class="hidden-xs" style="width: 150px;">Удалено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="5" class="text-muted text-center">Корзина пуста.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left text-muted small">
+            Элементы хранятся в корзине 30 дней, после чего удаляются автоматически.
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-danger btn-sm" data-action="purge-all">
+                <i class="fa fa-warning"></i> Очистить корзину
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/fields/groups.php
+++ b/src/Http/Dashboard/Views/fields/groups.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Группы полей';
+$this->params['breadcrumbs'][] = ['label' => 'Библиотека полей', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-info" data-role="field-groups">
+    <div class="box-header with-border">
+        <h3 class="box-title">Группы для организации полей</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-action="create-group">
+                <i class="fa fa-plus"></i> Добавить группу
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="field-groups-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Полей</th>
+                    <th class="hidden-xs">Описание</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Пока нет ни одной группы.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="field-group-modal" tabindex="-1" role="dialog" aria-labelledby="field-group-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="field-group-label">Новая группа</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="field-group-form">
+                    <div class="form-group">
+                        <label for="group-name">Название</label>
+                        <input type="text" class="form-control" id="group-name" placeholder="Основные данные">
+                    </div>
+                    <div class="form-group">
+                        <label for="group-description">Описание</label>
+                        <textarea class="form-control" rows="3" id="group-description"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="group-fields">Поля</label>
+                        <select multiple id="group-fields" class="form-control select2" data-placeholder="Выберите поля">
+                        </select>
+                        <p class="help-block">Выберите поля, которые будут отображаться внутри группы.</p>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-group">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/fields/index.php
+++ b/src/Http/Dashboard/Views/fields/index.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Библиотека полей';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="fields-library">
+    <div class="box-header with-border">
+        <h3 class="box-title">Поле &mdash; строитель блоков контента</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-success" data-action="create-field">
+                    <i class="fa fa-plus"></i> Новое поле
+                </button>
+                <button type="button" class="btn btn-default" data-action="export-fields">
+                    <i class="fa fa-download"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="fields-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Тип</th>
+                    <th class="hidden-xs">Использований</th>
+                    <th class="hidden-xs" style="width: 160px;">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-center text-muted">Добавьте первое поле, чтобы начать.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left text-muted small">
+            Управляйте типами полей и их настройками.
+        </div>
+        <div class="pull-right">
+            <?= Html::a('<i class="fa fa-book"></i> Документация', 'https://setkacms.dev/docs', [
+                'class' => 'btn btn-default btn-sm',
+                'target' => '_blank',
+                'rel' => 'noopener',
+            ]) ?>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="field-create" tabindex="-1" role="dialog" aria-labelledby="field-create-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="field-create-label">Новое поле</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="field-form">
+                    <div class="form-group">
+                        <label for="field-name">Название</label>
+                        <input type="text" class="form-control" id="field-name" placeholder="Например: Заголовок">
+                    </div>
+                    <div class="form-group">
+                        <label for="field-type">Тип</label>
+                        <select id="field-type" class="form-control select2">
+                            <option value="text">Текст</option>
+                            <option value="textarea">Многострочный текст</option>
+                            <option value="relation">Связь</option>
+                            <option value="media">Медиа</option>
+                        </select>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" checked> Обязательное</label>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-field">Создать</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/integrations/graphql.php
+++ b/src/Http/Dashboard/Views/integrations/graphql.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'GraphQL';
+$this->params['breadcrumbs'][] = ['label' => 'Интеграции', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="graphql">
+    <div class="box-header with-border">
+        <h3 class="box-title">GraphQL Playground</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="open-playground">
+                <i class="fa fa-external-link"></i> Открыть в новой вкладке
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">Схема GraphQL будет сгенерирована автоматически. Здесь появится интерактивный Playground.</p>
+        <pre class="pre-scrollable" data-role="graphql-schema"># Schema preview will be available soon.</pre>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/integrations/index.php
+++ b/src/Http/Dashboard/Views/integrations/index.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Интеграции';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="row" data-role="integrations">
+    <div class="col-md-4">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">REST API</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Получайте и отправляйте данные через REST API.</p>
+                <?= Html::a('<i class="fa fa-cloud"></i> Открыть', ['rest'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">GraphQL</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Соберите данные в одном запросе через GraphQL-эндпоинт.</p>
+                <?= Html::a('<i class="fa fa-code"></i> Открыть', ['graphql'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Webhooks</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Отправляйте уведомления во внешние сервисы.</p>
+                <?= Html::a('<i class="fa fa-share-alt"></i> Настроить', ['webhooks'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/integrations/rest.php
+++ b/src/Http/Dashboard/Views/integrations/rest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'REST API';
+$this->params['breadcrumbs'][] = ['label' => 'Интеграции', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="rest-api">
+    <div class="box-header with-border">
+        <h3 class="box-title">API-ключи</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#api-token-modal">
+                <i class="fa fa-key"></i> Создать ключ
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">Используйте ключи для доступа внешних приложений к REST API.</p>
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="api-tokens-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Токен</th>
+                    <th class="hidden-xs">Права</th>
+                    <th style="width: 160px;" class="hidden-xs">Создан</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Ключи ещё не созданы.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="api-token-modal" tabindex="-1" role="dialog" aria-labelledby="api-token-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="api-token-label">Новый API-ключ</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="api-token-form">
+                    <div class="form-group">
+                        <label for="token-name">Название</label>
+                        <input type="text" id="token-name" class="form-control" placeholder="Интеграция с CRM">
+                    </div>
+                    <div class="form-group">
+                        <label for="token-scope">Права доступа</label>
+                        <select multiple id="token-scope" class="form-control select2" data-placeholder="Выберите права">
+                            <option value="read">Чтение</option>
+                            <option value="write">Запись</option>
+                            <option value="publish">Публикация</option>
+                        </select>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="create-token">Создать ключ</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/integrations/webhooks.php
+++ b/src/Http/Dashboard/Views/integrations/webhooks.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Webhooks';
+$this->params['breadcrumbs'][] = ['label' => 'Интеграции', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="webhooks">
+    <div class="box-header with-border">
+        <h3 class="box-title">Триггеры</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#webhook-modal">
+                <i class="fa fa-plus"></i> Добавить webhook
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="webhooks-table">
+                <thead>
+                <tr>
+                    <th>Событие</th>
+                    <th class="hidden-xs">URL</th>
+                    <th class="hidden-xs">Формат</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Webhook-и ещё не добавлены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="webhook-modal" tabindex="-1" role="dialog" aria-labelledby="webhook-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="webhook-modal-label">Новый webhook</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="webhook-form">
+                    <div class="form-group">
+                        <label for="webhook-event">Событие</label>
+                        <select id="webhook-event" class="form-control select2">
+                            <option value="element.published">Публикация элемента</option>
+                            <option value="element.updated">Обновление элемента</option>
+                            <option value="collection.updated">Изменение коллекции</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="webhook-url">URL</label>
+                        <input type="url" id="webhook-url" class="form-control" placeholder="https://example.com/webhook">
+                    </div>
+                    <div class="form-group">
+                        <label for="webhook-format">Формат</label>
+                        <select id="webhook-format" class="form-control">
+                            <option value="json">JSON</option>
+                            <option value="form">Form-Data</option>
+                        </select>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-webhook">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/layouts/left.php
+++ b/src/Http/Dashboard/Views/layouts/left.php
@@ -58,21 +58,21 @@ $menuItems = [
     ],
     [
         'label' => '<i class="fa fa-picture-o"></i> <span>Медиа</span>' . $caret,
-        'url' => Url::to(['/dashboard/assets/library']),
+        'url' => Url::to(['/dashboard/media/library']),
         'options' => ['class' => 'treeview'],
         'items' => [
             [
                 'label' => '<i class="fa fa-image"></i> Библиотека',
-                'url' => Url::to(['/dashboard/assets/library']),
-                'active' => $equalsRoute('dashboard/assets/library'),
+                'url' => Url::to(['/dashboard/media/library']),
+                'active' => $equalsRoute('dashboard/media/library'),
             ],
             [
                 'label' => '<i class="fa fa-upload"></i> Загрузки',
-                'url' => Url::to(['/dashboard/assets/upload']),
-                'active' => $equalsRoute('dashboard/assets/upload'),
+                'url' => Url::to(['/dashboard/media/upload']),
+                'active' => $equalsRoute('dashboard/media/upload'),
             ],
         ],
-        'active' => $inSection('dashboard/assets'),
+        'active' => $inSection('dashboard/media'),
     ],
     '<li class="header">Структура</li>',
     [
@@ -100,21 +100,21 @@ $menuItems = [
     ],
     [
         'label' => '<i class="fa fa-sitemap"></i> <span>Таксономии</span>' . $caret,
-        'url' => Url::to(['/dashboard/taxonomy/index']),
+        'url' => Url::to(['/dashboard/taxonomies/index']),
         'options' => ['class' => 'treeview'],
         'items' => [
             [
                 'label' => '<i class="fa fa-bookmark"></i> Таксономии',
-                'url' => Url::to(['/dashboard/taxonomy/index']),
-                'active' => $equalsRoute('dashboard/taxonomy/index'),
+                'url' => Url::to(['/dashboard/taxonomies/index']),
+                'active' => $equalsRoute('dashboard/taxonomies/index'),
             ],
             [
                 'label' => '<i class="fa fa-tags"></i> Термины',
-                'url' => Url::to(['/dashboard/taxonomy/terms']),
-                'active' => $equalsRoute('dashboard/taxonomy/terms'),
+                'url' => Url::to(['/dashboard/taxonomies/terms']),
+                'active' => $equalsRoute('dashboard/taxonomies/terms'),
             ],
         ],
-        'active' => $inSection('dashboard/taxonomy'),
+        'active' => $inSection('dashboard/taxonomies'),
     ],
     [
         'label' => '<i class="fa fa-link"></i> <span>Связи</span>',
@@ -142,8 +142,8 @@ $menuItems = [
     ],
     [
         'label' => '<i class="fa fa-id-badge"></i> <span>Роли и доступ</span>',
-        'url' => Url::to(['/dashboard/users/roles']),
-        'active' => $inSection('dashboard/users/roles'),
+        'url' => Url::to(['/dashboard/roles/index']),
+        'active' => $inSection('dashboard/roles'),
     ],
     [
         'label' => '<i class="fa fa-building"></i> <span>Рабочие пространства</span>' . $caret,
@@ -210,6 +210,17 @@ $menuItems = [
         ],
         'active' => $inSection('dashboard/integrations'),
     ],
+    '<li class="header">Процессы</li>',
+    [
+        'label' => '<i class="fa fa-language"></i> <span>Локализация</span>',
+        'url' => Url::to(['/dashboard/localization/index']),
+        'active' => $inSection('dashboard/localization'),
+    ],
+    [
+        'label' => '<i class="fa fa-random"></i> <span>Воркфлоу</span>',
+        'url' => Url::to(['/dashboard/workflow/index']),
+        'active' => $inSection('dashboard/workflow'),
+    ],
     '<li class="header">Система</li>',
     [
         'label' => '<i class="fa fa-cogs"></i> <span>Настройки</span>' . $caret,
@@ -269,7 +280,7 @@ $menuItems = [
         </div>
 
         <!-- search form -->
-        <form action="#" method="get" class="sidebar-form">
+        <form action="<?= Url::to(['/dashboard/search/index']) ?>" method="get" class="sidebar-form">
             <div class="input-group">
                 <input type="text" name="q" class="form-control" placeholder="Search..."/>
               <span class="input-group-btn">

--- a/src/Http/Dashboard/Views/localization/index.php
+++ b/src/Http/Dashboard/Views/localization/index.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Локализация';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="row" data-role="localization">
+    <div class="col-md-6">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Языки</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Управляйте доступными языками интерфейса и контента.</p>
+                <?= Html::a('<i class="fa fa-language"></i> Настроить', ['languages'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Переводы</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Подготовьте перевод интерфейса и словарей.</p>
+                <?= Html::a('<i class="fa fa-pencil"></i> Открыть', ['translations'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/localization/languages.php
+++ b/src/Http/Dashboard/Views/localization/languages.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Языки';
+$this->params['breadcrumbs'][] = ['label' => 'Локализация', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="languages">
+    <div class="box-header with-border">
+        <h3 class="box-title">Доступные языки</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#language-modal">
+                <i class="fa fa-plus"></i> Добавить язык
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="languages-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Код</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Языки не настроены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="language-modal" tabindex="-1" role="dialog" aria-labelledby="language-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="language-modal-label">Новый язык</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="language-form">
+                    <div class="form-group">
+                        <label for="language-name">Название</label>
+                        <input type="text" id="language-name" class="form-control" placeholder="Deutsch">
+                    </div>
+                    <div class="form-group">
+                        <label for="language-code">Код</label>
+                        <input type="text" id="language-code" class="form-control" placeholder="de">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-language">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/localization/translations.php
+++ b/src/Http/Dashboard/Views/localization/translations.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Переводы';
+$this->params['breadcrumbs'][] = ['label' => 'Локализация', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="translations">
+    <div class="box-header with-border">
+        <h3 class="box-title">Словари переводов</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="import-translations">
+                <i class="fa fa-upload"></i> Импорт
+            </button>
+            <button type="button" class="btn btn-default btn-sm" data-action="export-translations">
+                <i class="fa fa-download"></i> Экспорт
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="translations-table">
+                <thead>
+                <tr>
+                    <th>Ключ</th>
+                    <th class="hidden-xs">Исходный текст</th>
+                    <th class="hidden-xs">Перевод</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Переводы ещё не добавлены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/media/library.php
+++ b/src/Http/Dashboard/Views/media/library.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Медиатека';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="media-library">
+    <div class="box-header with-border">
+        <h3 class="box-title">Библиотека файлов</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <?= Html::a('<i class="fa fa-upload"></i> Загрузить', ['upload'], [
+                    'class' => 'btn btn-success',
+                    'data-pjax' => '0',
+                ]) ?>
+                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#media-filters">
+                    <i class="fa fa-filter"></i>
+                </button>
+                <button type="button" class="btn btn-default" data-action="refresh-library">
+                    <i class="fa fa-refresh"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="row margin-bottom">
+            <div class="col-sm-6">
+                <div class="input-group input-group-sm">
+                    <span class="input-group-addon"><i class="fa fa-search"></i></span>
+                    <input type="search" class="form-control" placeholder="Поиск по названию или тегам" data-role="media-search">
+                </div>
+            </div>
+            <div class="col-sm-6 text-right">
+                <div class="btn-group btn-group-sm" data-role="media-view-mode">
+                    <button type="button" class="btn btn-default active" data-mode="grid"><i class="fa fa-th"></i></button>
+                    <button type="button" class="btn btn-default" data-mode="list"><i class="fa fa-list"></i></button>
+                </div>
+            </div>
+        </div>
+        <div class="row" data-role="media-grid">
+            <div class="col-sm-3">
+                <div class="thumbnail">
+                    <img src="https://via.placeholder.com/300x200?text=Preview" alt="Preview">
+                    <div class="caption">
+                        <h5>demo.jpg</h5>
+                        <p class="small text-muted">Размер 1.2 МБ</p>
+                        <p>
+                            <button type="button" class="btn btn-primary btn-xs" data-action="choose-file">Выбрать</button>
+                            <button type="button" class="btn btn-default btn-xs" data-action="details">Подробнее</button>
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-3">
+                <div class="thumbnail placeholder">
+                    <div class="caption text-center text-muted">
+                        <i class="fa fa-picture-o fa-3x"></i>
+                        <p>Новые файлы появятся после загрузки.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left text-muted small">
+            Выбрано: <span data-role="selected-count">0</span>
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-default btn-sm" data-action="clear-selection">Сбросить выбор</button>
+            <button type="button" class="btn btn-primary btn-sm" data-action="insert-selection">Использовать</button>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="media-filters" tabindex="-1" role="dialog" aria-labelledby="media-filters-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="media-filters-label">Фильтры медиатеки</h4>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="media-type" class="control-label">Тип файла</label>
+                    <select id="media-type" class="form-control select2">
+                        <option value="">Все</option>
+                        <option value="image">Изображения</option>
+                        <option value="video">Видео</option>
+                        <option value="audio">Аудио</option>
+                        <option value="document">Документы</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="media-period" class="control-label">Период загрузки</label>
+                    <select id="media-period" class="form-control">
+                        <option value="30">За 30 дней</option>
+                        <option value="90">За 90 дней</option>
+                        <option value="all">За всё время</option>
+                    </select>
+                </div>
+                <div class="checkbox">
+                    <label><input type="checkbox"> Показать только несвязанные файлы</label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="apply-media-filters">Применить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/media/upload.php
+++ b/src/Http/Dashboard/Views/media/upload.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Загрузка файлов';
+$this->params['breadcrumbs'][] = ['label' => 'Медиатека', 'url' => ['library']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-success" data-role="media-upload">
+    <div class="box-header with-border">
+        <h3 class="box-title">Загрузка в медиатеку</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#upload-settings">
+                <i class="fa fa-cog"></i>
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="upload-drop-zone text-center" data-role="upload-drop-zone">
+            <p><i class="fa fa-cloud-upload fa-3x"></i></p>
+            <p>Перетащите файлы сюда или воспользуйтесь кнопкой ниже.</p>
+            <button type="button" class="btn btn-primary" data-action="choose-files">Выбрать файлы</button>
+        </div>
+        <hr>
+        <table class="table table-striped" data-role="upload-queue">
+            <thead>
+            <tr>
+                <th>Файл</th>
+                <th style="width: 140px;">Размер</th>
+                <th style="width: 220px;">Прогресс</th>
+                <th style="width: 100px;">Статус</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr class="empty">
+                <td colspan="4" class="text-muted text-center">Файлы ещё не выбраны.</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left text-muted small">
+            Максимальный размер файла 50 МБ.
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-default btn-sm" data-action="clear-queue">Очистить очередь</button>
+            <button type="button" class="btn btn-success btn-sm" data-action="start-upload">
+                <i class="fa fa-upload"></i> Начать загрузку
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="upload-settings" tabindex="-1" role="dialog" aria-labelledby="upload-settings-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="upload-settings-label">Настройки загрузки</h4>
+            </div>
+            <div class="modal-body">
+                <div class="checkbox">
+                    <label><input type="checkbox" checked> Оптимизировать изображения</label>
+                </div>
+                <div class="checkbox">
+                    <label><input type="checkbox"> Создавать превью автоматически</label>
+                </div>
+                <div class="form-group">
+                    <label for="upload-collection">Добавить в коллекцию</label>
+                    <select id="upload-collection" class="form-control select2" data-placeholder="Не назначать">
+                        <option value=""></option>
+                    </select>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/plugins/index.php
+++ b/src/Http/Dashboard/Views/plugins/index.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Плагины';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="plugins">
+    <div class="box-header with-border">
+        <h3 class="box-title">Установленные плагины</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <?= Html::a('<i class="fa fa-download"></i> Установить новый', ['install'], [
+                    'class' => 'btn btn-success',
+                    'data-pjax' => '0',
+                ]) ?>
+                <?= Html::a('<i class="fa fa-refresh"></i> Обновления', ['updates'], [
+                    'class' => 'btn btn-default',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="plugins-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Версия</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th style="width: 150px;" class="hidden-xs">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Плагины ещё не установлены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="plugin-details" tabindex="-1" role="dialog" aria-labelledby="plugin-details-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="plugin-details-label">Информация о плагине</h4>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted">Карточка с описанием плагина появится после интеграции маркетплейса.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/plugins/install.php
+++ b/src/Http/Dashboard/Views/plugins/install.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Установка плагина';
+$this->params['breadcrumbs'][] = ['label' => 'Плагины', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-success" data-role="plugin-install">
+    <div class="box-header with-border">
+        <h3 class="box-title">Установить из архива или маркетплейса</h3>
+    </div>
+    <div class="box-body">
+        <div class="row">
+            <div class="col-md-6">
+                <h4>Загрузка архива</h4>
+                <p class="text-muted">Выберите ZIP-файл плагина и загрузите его.</p>
+                <div class="form-group">
+                    <label for="plugin-archive">Файл плагина</label>
+                    <input type="file" id="plugin-archive" class="form-control">
+                </div>
+                <button type="button" class="btn btn-primary" data-action="upload-plugin">
+                    <i class="fa fa-upload"></i> Загрузить
+                </button>
+            </div>
+            <div class="col-md-6">
+                <h4>Маркетплейс</h4>
+                <p class="text-muted">Поиск по каталогу расширений будет доступен позже.</p>
+                <div class="input-group input-group-sm">
+                    <input type="search" class="form-control" placeholder="Поиск плагинов" disabled>
+                    <span class="input-group-btn">
+                        <button class="btn btn-default" type="button" disabled><i class="fa fa-search"></i></button>
+                    </span>
+                </div>
+                <div class="well well-sm" style="margin-top: 15px;">
+                    <p>Подключите свою учётную запись Setka для синхронизации покупок.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/plugins/updates.php
+++ b/src/Http/Dashboard/Views/plugins/updates.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Обновления плагинов';
+$this->params['breadcrumbs'][] = ['label' => 'Плагины', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-warning" data-role="plugin-updates">
+    <div class="box-header with-border">
+        <h3 class="box-title">Доступные обновления</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="refresh-updates">
+                <i class="fa fa-refresh"></i>
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="plugin-updates-table">
+                <thead>
+                <tr>
+                    <th>Плагин</th>
+                    <th class="hidden-xs">Текущая версия</th>
+                    <th class="hidden-xs">Новая версия</th>
+                    <th style="width: 140px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Обновления не найдены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-primary btn-sm" data-action="update-all" disabled>
+            <i class="fa fa-play"></i> Обновить всё
+        </button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/relations/index.php
+++ b/src/Http/Dashboard/Views/relations/index.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Связи';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="relations">
+    <div class="box-header with-border">
+        <h3 class="box-title">Связи между элементами</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#relation-modal">
+                <i class="fa fa-plus"></i> Добавить связь
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="relations-table">
+                <thead>
+                <tr>
+                    <th>Имя</th>
+                    <th class="hidden-xs">Тип</th>
+                    <th class="hidden-xs">Источник</th>
+                    <th class="hidden-xs">Получатель</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="5" class="text-center text-muted">Связи ещё не настроены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="relation-modal" tabindex="-1" role="dialog" aria-labelledby="relation-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="relation-modal-label">Новая связь</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="relation-form">
+                    <div class="form-group">
+                        <label for="relation-name">Название</label>
+                        <input type="text" id="relation-name" class="form-control" placeholder="Например: Автор">
+                    </div>
+                    <div class="form-group">
+                        <label for="relation-type">Тип</label>
+                        <select id="relation-type" class="form-control select2">
+                            <option value="one-to-one">Один к одному</option>
+                            <option value="one-to-many">Один ко многим</option>
+                            <option value="many-to-many">Многие ко многим</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="relation-source">Источник</label>
+                        <select id="relation-source" class="form-control select2"></select>
+                    </div>
+                    <div class="form-group">
+                        <label for="relation-target">Получатель</label>
+                        <select id="relation-target" class="form-control select2"></select>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-relation">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/roles/index.php
+++ b/src/Http/Dashboard/Views/roles/index.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Роли и доступ';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="roles">
+    <div class="box-header with-border">
+        <h3 class="box-title">Ролевые модели</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#role-modal">
+                <i class="fa fa-plus"></i> Добавить роль
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="row">
+            <div class="col-md-6">
+                <div class="table-responsive">
+                    <table class="table table-striped" data-role="roles-table">
+                        <thead>
+                        <tr>
+                            <th>Название</th>
+                            <th class="hidden-xs">Пользователей</th>
+                            <th style="width: 120px;" class="text-right">Действия</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr class="empty">
+                            <td colspan="3" class="text-muted text-center">Роли ещё не настроены.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="box box-solid" data-role="role-permissions">
+                    <div class="box-header with-border">
+                        <h4 class="box-title">Права доступа</h4>
+                    </div>
+                    <div class="box-body">
+                        <p class="text-muted">Выберите роль слева, чтобы просмотреть разрешения.</p>
+                        <ul class="list-group">
+                            <li class="list-group-item">Управление элементами</li>
+                            <li class="list-group-item">Управление коллекциями</li>
+                            <li class="list-group-item">Настройки системы</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="role-modal" tabindex="-1" role="dialog" aria-labelledby="role-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="role-modal-label">Новая роль</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="role-form">
+                    <div class="form-group">
+                        <label for="role-name">Название</label>
+                        <input type="text" id="role-name" class="form-control" placeholder="Редактор">
+                    </div>
+                    <div class="form-group">
+                        <label>Разрешения</label>
+                        <div class="checkbox"><label><input type="checkbox" checked> Управлять элементами</label></div>
+                        <div class="checkbox"><label><input type="checkbox"> Публиковать контент</label></div>
+                        <div class="checkbox"><label><input type="checkbox"> Настраивать плагины</label></div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-role">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/schemas/index.php
+++ b/src/Http/Dashboard/Views/schemas/index.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Схемы данных';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="schemas">
+    <div class="box-header with-border">
+        <h3 class="box-title">Конструктор схем</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-success" data-action="create-schema">
+                    <i class="fa fa-plus"></i> Новая схема
+                </button>
+                <button type="button" class="btn btn-default" data-action="import-schema">
+                    <i class="fa fa-upload"></i> Импорт
+                </button>
+                <button type="button" class="btn btn-default" data-action="export-schema">
+                    <i class="fa fa-download"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="row">
+            <div class="col-md-6">
+                <div class="table-responsive">
+                    <table class="table table-hover" data-role="schemas-table">
+                        <thead>
+                        <tr>
+                            <th>Название</th>
+                            <th class="hidden-xs">Коллекция</th>
+                            <th class="hidden-xs" style="width: 150px;">Обновлено</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr class="empty">
+                            <td colspan="3" class="text-center text-muted">Схемы будут отображены после настройки.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="box box-solid" data-role="schema-preview">
+                    <div class="box-header with-border">
+                        <h4 class="box-title">Предпросмотр</h4>
+                    </div>
+                    <div class="box-body">
+                        <p class="text-muted">Выберите схему в таблице, чтобы увидеть список полей и структуру.</p>
+                        <ul class="list-group" data-role="schema-fields">
+                            <li class="list-group-item text-muted">Поля будут показаны здесь.</li>
+                        </ul>
+                    </div>
+                    <div class="box-footer text-right">
+                        <?= Html::a('<i class="fa fa-pencil"></i> Редактировать', '#', [
+                            'class' => 'btn btn-primary btn-sm disabled',
+                            'data-role' => 'edit-schema',
+                        ]) ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="schema-import" tabindex="-1" role="dialog" aria-labelledby="schema-import-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="schema-import-label">Импорт схемы</h4>
+            </div>
+            <div class="modal-body">
+                <p>Импорт схем будет доступен позже. Поддерживаются форматы JSON и YAML.</p>
+                <div class="form-group">
+                    <label class="control-label">Файл со схемой</label>
+                    <input type="file" class="form-control">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+                <button type="button" class="btn btn-primary" disabled>Импортировать</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/search/index.php
+++ b/src/Http/Dashboard/Views/search/index.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Поиск';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="global-search">
+    <div class="box-header with-border">
+        <h3 class="box-title">Глобальный поиск</h3>
+    </div>
+    <div class="box-body">
+        <form class="form-inline margin-bottom">
+            <div class="input-group input-group-lg" style="width: 100%;">
+                <span class="input-group-addon"><i class="fa fa-search"></i></span>
+                <input type="search" class="form-control" placeholder="Введите запрос" autofocus>
+            </div>
+        </form>
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="search-results">
+                <thead>
+                <tr>
+                    <th>Результат</th>
+                    <th class="hidden-xs">Тип</th>
+                    <th class="hidden-xs">Дата</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="3" class="text-muted text-center">Введите запрос, чтобы увидеть результаты.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/settings/general.php
+++ b/src/Http/Dashboard/Views/settings/general.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Общие настройки';
+$this->params['breadcrumbs'][] = ['label' => 'Настройки', 'url' => ['general']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="settings-general">
+    <div class="box-header with-border">
+        <h3 class="box-title">Основные параметры проекта</h3>
+    </div>
+    <div class="box-body">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <label for="setting-site-name" class="col-sm-3 control-label">Название проекта</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="setting-site-name" placeholder="Setka CMS">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="setting-site-url" class="col-sm-3 control-label">Основной домен</label>
+                <div class="col-sm-9">
+                    <input type="url" class="form-control" id="setting-site-url" placeholder="https://example.com">
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Язык интерфейса</label>
+                <div class="col-sm-9">
+                    <select class="form-control select2" data-role="setting-language">
+                        <option value="ru">Русский</option>
+                        <option value="en">English</option>
+                    </select>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-default" data-action="reset-settings">Сбросить</button>
+        <button type="button" class="btn btn-success" data-action="save-settings">
+            <i class="fa fa-save"></i> Сохранить изменения
+        </button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/settings/security.php
+++ b/src/Http/Dashboard/Views/settings/security.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Безопасность';
+$this->params['breadcrumbs'][] = ['label' => 'Настройки', 'url' => ['general']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-danger" data-role="settings-security">
+    <div class="box-header with-border">
+        <h3 class="box-title">Параметры безопасности</h3>
+    </div>
+    <div class="box-body">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <label for="security-two-factor" class="col-sm-3 control-label">Двухфакторная аутентификация</label>
+                <div class="col-sm-9">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="security-two-factor"> Требовать 2FA для всех пользователей</label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Минимальная длина пароля</label>
+                <div class="col-sm-9">
+                    <input type="number" class="form-control" value="12" min="8" max="64">
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Политика сессий</label>
+                <div class="col-sm-9">
+                    <select class="form-control">
+                        <option value="8">Автовыход через 8 часов</option>
+                        <option value="24">Автовыход через 24 часа</option>
+                        <option value="0">Не ограничивать</option>
+                    </select>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-success" data-action="save-security">
+            <i class="fa fa-save"></i> Сохранить
+        </button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/settings/storage.php
+++ b/src/Http/Dashboard/Views/settings/storage.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Хранилище';
+$this->params['breadcrumbs'][] = ['label' => 'Настройки', 'url' => ['general']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-info" data-role="settings-storage">
+    <div class="box-header with-border">
+        <h3 class="box-title">Подключение хранилищ</h3>
+    </div>
+    <div class="box-body">
+        <div class="row">
+            <div class="col-md-6">
+                <h4>Локальное хранилище</h4>
+                <p class="text-muted">Используется по умолчанию. Настройки появятся после интеграции файловой системы.</p>
+            </div>
+            <div class="col-md-6">
+                <h4>Облако</h4>
+                <div class="form-group">
+                    <label for="storage-driver">Провайдер</label>
+                    <select id="storage-driver" class="form-control">
+                        <option value="s3">Amazon S3</option>
+                        <option value="gcs">Google Cloud Storage</option>
+                        <option value="azure">Azure Blob Storage</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="storage-bucket">Bucket</label>
+                    <input type="text" class="form-control" id="storage-bucket" placeholder="setka-content">
+                </div>
+                <div class="form-group">
+                    <label for="storage-region">Регион</label>
+                    <input type="text" class="form-control" id="storage-region" placeholder="eu-central-1">
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-success" data-action="save-storage">
+            <i class="fa fa-save"></i> Сохранить
+        </button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/system/jobs.php
+++ b/src/Http/Dashboard/Views/system/jobs.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Фоновые задачи';
+$this->params['breadcrumbs'][] = ['label' => 'Система', 'url' => ['logs']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="system-jobs">
+    <div class="box-header with-border">
+        <h3 class="box-title">Мониторинг фоновых задач</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="jobs-refresh">
+                <i class="fa fa-refresh"></i>
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="jobs-table">
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th class="hidden-xs">Описание</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th style="width: 160px;" class="hidden-xs">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Нет активных задач.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-default btn-sm" data-action="jobs-history">История</button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/system/logs.php
+++ b/src/Http/Dashboard/Views/system/logs.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Системные журналы';
+$this->params['breadcrumbs'][] = ['label' => 'Система', 'url' => ['logs']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="system-logs">
+    <div class="box-header with-border">
+        <h3 class="box-title">Журналы</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="download-logs">
+                <i class="fa fa-download"></i>
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="form-inline margin-bottom">
+            <div class="form-group">
+                <label class="sr-only" for="log-level">Уровень</label>
+                <select id="log-level" class="form-control input-sm">
+                    <option value="">Все уровни</option>
+                    <option value="error">Error</option>
+                    <option value="warning">Warning</option>
+                    <option value="info">Info</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label class="sr-only" for="log-search">Поиск</label>
+                <input type="search" id="log-search" class="form-control input-sm" placeholder="Поиск по сообщениям">
+            </div>
+            <button type="button" class="btn btn-default btn-sm" data-action="apply-log-filters">
+                <i class="fa fa-filter"></i>
+            </button>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="logs-table">
+                <thead>
+                <tr>
+                    <th>Дата</th>
+                    <th>Уровень</th>
+                    <th>Сообщение</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="3" class="text-muted text-center">Записи журнала появятся после работы системы.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/system/queue.php
+++ b/src/Http/Dashboard/Views/system/queue.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Очереди';
+$this->params['breadcrumbs'][] = ['label' => 'Система', 'url' => ['logs']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="system-queue">
+    <div class="box-header with-border">
+        <h3 class="box-title">Задачи в очереди</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="queue-refresh">
+                <i class="fa fa-refresh"></i>
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="queue-table">
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th class="hidden-xs">Задача</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th class="hidden-xs" style="width: 160px;">Добавлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Очередь пуста.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-danger btn-sm" data-action="flush-queue">Очистить очередь</button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/taxonomies/index.php
+++ b/src/Http/Dashboard/Views/taxonomies/index.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Таксономии';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="taxonomies">
+    <div class="box-header with-border">
+        <h3 class="box-title">Управление таксономиями</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-success" data-action="create-taxonomy">
+                    <i class="fa fa-plus"></i> Новая таксономия
+                </button>
+                <?= Html::a('<i class="fa fa-tags"></i> Термины', ['terms'], [
+                    'class' => 'btn btn-default',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="taxonomies-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Слаг</th>
+                    <th class="hidden-xs">Связанных коллекций</th>
+                    <th style="width: 160px;" class="hidden-xs">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-center text-muted">Таксономии будут отображены после создания.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="taxonomy-create" tabindex="-1" role="dialog" aria-labelledby="taxonomy-create-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="taxonomy-create-label">Новая таксономия</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="taxonomy-form">
+                    <div class="form-group">
+                        <label for="taxonomy-name">Название</label>
+                        <input type="text" class="form-control" id="taxonomy-name" placeholder="Темы">
+                    </div>
+                    <div class="form-group">
+                        <label for="taxonomy-slug">Слаг</label>
+                        <input type="text" class="form-control" id="taxonomy-slug" placeholder="topics">
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" checked> Иерархическая</label>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-taxonomy">Создать</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/taxonomies/terms.php
+++ b/src/Http/Dashboard/Views/taxonomies/terms.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Термины таксономий';
+$this->params['breadcrumbs'][] = ['label' => 'Таксономии', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-info" data-role="taxonomy-terms">
+    <div class="box-header with-border">
+        <h3 class="box-title">Термины</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <button type="button" class="btn btn-success" data-action="create-term">
+                    <i class="fa fa-plus"></i> Добавить термин
+                </button>
+                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#terms-import">
+                    <i class="fa fa-upload"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="row margin-bottom">
+            <div class="col-sm-6">
+                <div class="input-group input-group-sm">
+                    <span class="input-group-addon"><i class="fa fa-search"></i></span>
+                    <input type="search" class="form-control" placeholder="Поиск по терминам" data-role="term-search">
+                </div>
+            </div>
+            <div class="col-sm-6 text-right">
+                <select class="form-control input-sm" data-role="taxonomy-filter" style="max-width: 220px;">
+                    <option value="">Все таксономии</option>
+                </select>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="terms-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Слаг</th>
+                    <th class="hidden-xs">Таксономия</th>
+                    <th style="width: 120px;" class="hidden-xs">Использований</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-center text-muted">Список терминов пуст.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left text-muted small">
+            Используйте drag-n-drop для изменения иерархии (будет доступно позже).
+        </div>
+        <div class="pull-right">
+            <?= Html::a('<i class="fa fa-angle-left"></i> К таксономиям', ['index'], [
+                'class' => 'btn btn-default btn-sm',
+                'data-pjax' => '0',
+            ]) ?>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="terms-import" tabindex="-1" role="dialog" aria-labelledby="terms-import-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="terms-import-label">Импорт терминов</h4>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted">Поддержка импорта терминов появится после реализации backend.</p>
+                <div class="form-group">
+                    <label for="terms-file">Файл CSV</label>
+                    <input type="file" id="terms-file" class="form-control">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+                <button type="button" class="btn btn-primary" disabled>Импортировать</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/users/index.php
+++ b/src/Http/Dashboard/Views/users/index.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Пользователи';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="users">
+    <div class="box-header with-border">
+        <h3 class="box-title">Команда проекта</h3>
+        <div class="box-tools">
+            <div class="btn-group btn-group-sm">
+                <?= Html::a('<i class="fa fa-user-plus"></i> Пригласить', ['invite'], [
+                    'class' => 'btn btn-success',
+                    'data-pjax' => '0',
+                ]) ?>
+                <?= Html::a('<i class="fa fa-id-badge"></i> Роли', ['/dashboard/roles/index'], [
+                    'class' => 'btn btn-default',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="users-table">
+                <thead>
+                <tr>
+                    <th>Имя</th>
+                    <th class="hidden-xs">E-mail</th>
+                    <th class="hidden-xs">Роль</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="5" class="text-muted text-center">Команда ещё не сформирована.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="user-roles" tabindex="-1" role="dialog" aria-labelledby="user-roles-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="user-roles-label">Назначение роли</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="user-role-form">
+                    <div class="form-group">
+                        <label for="user-role">Роль</label>
+                        <select id="user-role" class="form-control select2">
+                            <option value="admin">Администратор</option>
+                            <option value="editor">Редактор</option>
+                            <option value="author">Автор</option>
+                            <option value="viewer">Наблюдатель</option>
+                        </select>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox"> Отправить уведомление по email</label>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="assign-role">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/users/invite.php
+++ b/src/Http/Dashboard/Views/users/invite.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Приглашение пользователя';
+$this->params['breadcrumbs'][] = ['label' => 'Пользователи', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-success" data-role="user-invite">
+    <div class="box-header with-border">
+        <h3 class="box-title">Отправить приглашение</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#invite-template">
+                <i class="fa fa-envelope"></i> Шаблон письма
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <form class="form-horizontal" data-role="invite-form">
+            <div class="form-group">
+                <label for="invite-email" class="col-sm-3 control-label">E-mail</label>
+                <div class="col-sm-9">
+                    <input type="email" class="form-control" id="invite-email" placeholder="user@example.com">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="invite-role" class="col-sm-3 control-label">Роль</label>
+                <div class="col-sm-9">
+                    <select id="invite-role" class="form-control select2">
+                        <option value="editor">Редактор</option>
+                        <option value="author">Автор</option>
+                        <option value="viewer">Наблюдатель</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Рабочие пространства</label>
+                <div class="col-sm-9">
+                    <select multiple class="form-control select2" data-placeholder="Все">
+                        <option value="default">Основное</option>
+                        <option value="marketing">Маркетинг</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-3 col-sm-9">
+                    <div class="checkbox">
+                        <label><input type="checkbox" checked> Отправить письмо сразу</label>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox"> Требовать смену пароля при первом входе</label>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left">
+            <?= Html::a('<i class="fa fa-angle-left"></i> К списку', ['index'], [
+                'class' => 'btn btn-default btn-sm',
+                'data-pjax' => '0',
+            ]) ?>
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-default" data-action="save-draft">Сохранить черновик</button>
+            <button type="button" class="btn btn-success" data-action="send-invite">
+                <i class="fa fa-paper-plane"></i> Отправить приглашение
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="invite-template" tabindex="-1" role="dialog" aria-labelledby="invite-template-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="invite-template-label">Шаблон письма</h4>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted">Настройка текста приглашения появится после подключения почтового сервиса.</p>
+                <textarea class="form-control" rows="6" readonly>Здравствуйте! Вас приглашают в Setka CMS. Перейдите по ссылке, чтобы завершить регистрацию.</textarea>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/workflow/index.php
+++ b/src/Http/Dashboard/Views/workflow/index.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Рабочие процессы';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="row" data-role="workflow">
+    <div class="col-md-6">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Статусы</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Настройте этапы согласования контента.</p>
+                <?= Html::a('<i class="fa fa-list"></i> Управлять', ['states'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Переходы</h3>
+            </div>
+            <div class="box-body">
+                <p class="text-muted">Определите, кто и когда может менять статусы.</p>
+                <?= Html::a('<i class="fa fa-random"></i> Настроить', ['transitions'], [
+                    'class' => 'btn btn-primary btn-sm',
+                    'data-pjax' => '0',
+                ]) ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/workflow/states.php
+++ b/src/Http/Dashboard/Views/workflow/states.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Статусы рабочего процесса';
+$this->params['breadcrumbs'][] = ['label' => 'Рабочие процессы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="workflow-states">
+    <div class="box-header with-border">
+        <h3 class="box-title">Статусы</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#state-modal">
+                <i class="fa fa-plus"></i> Добавить статус
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="list-group" data-role="states-list">
+            <a href="#" class="list-group-item">Черновик</a>
+            <a href="#" class="list-group-item">На ревью</a>
+            <a href="#" class="list-group-item">Опубликовано</a>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="state-modal" tabindex="-1" role="dialog" aria-labelledby="state-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="state-modal-label">Новый статус</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="state-form">
+                    <div class="form-group">
+                        <label for="state-name">Название</label>
+                        <input type="text" id="state-name" class="form-control" placeholder="На проверке">
+                    </div>
+                    <div class="form-group">
+                        <label for="state-color">Цвет</label>
+                        <input type="color" id="state-color" class="form-control" value="#3c8dbc">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-state">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/workflow/transitions.php
+++ b/src/Http/Dashboard/Views/workflow/transitions.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Переходы рабочего процесса';
+$this->params['breadcrumbs'][] = ['label' => 'Рабочие процессы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="workflow-transitions">
+    <div class="box-header with-border">
+        <h3 class="box-title">Переходы</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#transition-modal">
+                <i class="fa fa-plus"></i> Добавить переход
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="transitions-table">
+                <thead>
+                <tr>
+                    <th>Из статуса</th>
+                    <th class="hidden-xs">В статус</th>
+                    <th class="hidden-xs">Роль</th>
+                    <th style="width: 120px;" class="text-right">Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Переходы не настроены.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="transition-modal" tabindex="-1" role="dialog" aria-labelledby="transition-modal-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="transition-modal-label">Новый переход</h4>
+            </div>
+            <div class="modal-body">
+                <form data-role="transition-form">
+                    <div class="form-group">
+                        <label for="transition-from">Из статуса</label>
+                        <select id="transition-from" class="form-control select2">
+                            <option value="draft">Черновик</option>
+                            <option value="review">На ревью</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="transition-to">В статус</label>
+                        <select id="transition-to" class="form-control select2">
+                            <option value="review">На ревью</option>
+                            <option value="published">Опубликовано</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="transition-role">Роль</label>
+                        <select id="transition-role" class="form-control select2">
+                            <option value="editor">Редактор</option>
+                            <option value="admin">Администратор</option>
+                        </select>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" data-action="save-transition">Сохранить</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/workspaces/create.php
+++ b/src/Http/Dashboard/Views/workspaces/create.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Новое рабочее пространство';
+$this->params['breadcrumbs'][] = ['label' => 'Рабочие пространства', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-success" data-role="workspace-form">
+    <div class="box-header with-border">
+        <h3 class="box-title">Создание пространства</h3>
+    </div>
+    <div class="box-body">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <label for="workspace-name" class="col-sm-3 control-label">Название</label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" id="workspace-name" placeholder="Например: Маркетинг">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="workspace-description" class="col-sm-3 control-label">Описание</label>
+                <div class="col-sm-9">
+                    <textarea id="workspace-description" class="form-control" rows="4"></textarea>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Коллекции</label>
+                <div class="col-sm-9">
+                    <select multiple class="form-control select2" data-role="workspace-collections"></select>
+                    <p class="help-block">Выберите коллекции, доступные в этом пространстве.</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Участники</label>
+                <div class="col-sm-9">
+                    <select multiple class="form-control select2" data-role="workspace-users"></select>
+                    <p class="help-block">Приглашения будут отправлены выбранным пользователям.</p>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="box-footer clearfix">
+        <div class="pull-left">
+            <?= Html::a('<i class="fa fa-angle-left"></i> К списку', ['index'], [
+                'class' => 'btn btn-default btn-sm',
+                'data-pjax' => '0',
+            ]) ?>
+        </div>
+        <div class="pull-right">
+            <button type="button" class="btn btn-default" data-action="save-draft">Сохранить черновик</button>
+            <button type="button" class="btn btn-success" data-action="create-workspace">
+                <i class="fa fa-check"></i> Создать
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/workspaces/index.php
+++ b/src/Http/Dashboard/Views/workspaces/index.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+
+$this->title = 'Рабочие пространства';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="workspaces">
+    <div class="box-header with-border">
+        <h3 class="box-title">Организация команд</h3>
+        <div class="box-tools">
+            <?= Html::a('<i class="fa fa-plus"></i> Новое пространство', ['create'], [
+                'class' => 'btn btn-success btn-sm',
+                'data-pjax' => '0',
+            ]) ?>
+        </div>
+    </div>
+    <div class="box-body">
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="workspaces-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Участников</th>
+                    <th class="hidden-xs">Коллекций</th>
+                    <th class="hidden-xs" style="width: 160px;">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="4" class="text-muted text-center">Нет созданных пространств.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="workspace-members" tabindex="-1" role="dialog" aria-labelledby="workspace-members-label">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="workspace-members-label">Участники</h4>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted">Список участников появится после интеграции.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Закрыть</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add dashboard controllers for content, structure, extensions, localization and system sections
- scaffold AdminLTE views for tables, forms and modals across every dashboard action
- register controller map defaults and refresh the sidebar navigation/search to point to the new pages

## Testing
- find src/Http/Dashboard/Controllers -name '*.php' -print0 | xargs -0 -n1 php -l
- find src/Http/Dashboard/Views -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68ccd67d305c832dacd7216abfb4b19a