### PR TITLE
Добавить современные виджеты на страницы дашборда

### DIFF
--- a/src/Http/Dashboard/Assets/DashboardAsset.php
+++ b/src/Http/Dashboard/Assets/DashboardAsset.php
@@ -22,6 +22,7 @@ class DashboardAsset extends AssetBundle
     ];
 
     public $depends = [
+        \yii\web\YiiAsset::class,
         \dmstr\web\AdminLteAsset::class,
     ];
 
@@ -43,6 +44,46 @@ class DashboardAsset extends AssetBundle
             'select2',
             ['select2.min.css'],
             ['select2.full.min.js'],
+            [\dmstr\web\AdminLteAsset::class]
+        );
+
+        AdminLtePlugin::register(
+            $view,
+            'flatpickr',
+            ['flatpickr.min.css'],
+            ['flatpickr.min.js'],
+            [\dmstr\web\AdminLteAsset::class]
+        );
+
+        AdminLtePlugin::register(
+            $view,
+            'dropzone',
+            ['dropzone.css'],
+            ['dropzone.js'],
+            [\dmstr\web\AdminLteAsset::class]
+        );
+
+        AdminLtePlugin::register(
+            $view,
+            'sortablejs',
+            [],
+            ['Sortable.min.js'],
+            [\dmstr\web\AdminLteAsset::class]
+        );
+
+        AdminLtePlugin::register(
+            $view,
+            'tinymce',
+            ['skins/lightgray/skin.min.css'],
+            ['tinymce.min.js'],
+            [\dmstr\web\AdminLteAsset::class]
+        );
+
+        AdminLtePlugin::register(
+            $view,
+            'codemirror',
+            ['codemirror.css'],
+            ['codemirror.js', 'mode/javascript/javascript.js'],
             [\dmstr\web\AdminLteAsset::class]
         );
     }

--- a/src/Http/Dashboard/Assets/dist/css/dashboard.css
+++ b/src/Http/Dashboard/Assets/dist/css/dashboard.css
@@ -40,3 +40,28 @@ h1, h2, h3, h4, h5, h6 {
 #bulk-action-result {
   padding-top: 8px;
 }
+
+[data-role="media-dropzone"] {
+  border: 2px dashed #d2d6de;
+  background-color: #f9f9f9;
+  padding: 20px;
+  text-align: center;
+}
+
+[data-role="media-dropzone"] .dz-message {
+  font-size: 14px;
+  color: #9e9e9e;
+}
+
+[data-role="states-list"] .list-group-item {
+  cursor: move;
+}
+
+.state-handle {
+  margin-right: 8px;
+  color: #9e9e9e;
+}
+
+.workflow-state-ghost {
+  background-color: #ecf5ff !important;
+}

--- a/src/Http/Dashboard/Assets/dist/js/dashboard.js
+++ b/src/Http/Dashboard/Assets/dist/js/dashboard.js
@@ -7,6 +7,11 @@
         init: function () {
             this.initSelect2();
             this.initDataTables();
+            this.initFlatpickr();
+            this.initDropzone();
+            this.initSortable();
+            this.initTinyMCE();
+            this.initCodeMirror();
             this.bindSelectAll();
             this.bindFiltering();
             this.bindBulkActions();
@@ -77,6 +82,130 @@
             if (firstRow.length) {
                 self.selectRow(firstRow);
             }
+        },
+
+        initFlatpickr: function () {
+            if (typeof window.flatpickr === 'undefined') {
+                return;
+            }
+
+            var selectors = '[data-role="filter-date-from"], [data-role="filter-date-to"]';
+
+            $(selectors).each(function () {
+                if (this._flatpickr) {
+                    return;
+                }
+
+                window.flatpickr(this, {
+                    dateFormat: 'd.m.Y',
+                    altInput: true,
+                    altFormat: 'd.m.Y',
+                    allowInput: true
+                });
+            });
+        },
+
+        initDropzone: function () {
+            if (typeof window.Dropzone === 'undefined') {
+                return;
+            }
+
+            if (window.Dropzone.autoDiscover) {
+                window.Dropzone.autoDiscover = false;
+            }
+
+            $('[data-role="media-dropzone"]').each(function () {
+                var element = this;
+
+                if (element.dropzone) {
+                    return;
+                }
+
+                var options = {
+                    url: $(element).data('upload-url') || '#',
+                    autoProcessQueue: false,
+                    addRemoveLinks: true,
+                    dictDefaultMessage: 'Перетащите файлы сюда или нажмите для выбора.'
+                };
+
+                var dropzone = new window.Dropzone(element, options);
+                $(element).data('dropzone', dropzone);
+            });
+        },
+
+        initSortable: function () {
+            if (typeof window.Sortable === 'undefined') {
+                return;
+            }
+
+            $('[data-role="states-list"]').each(function () {
+                var element = this;
+
+                if (element._sortableInstance) {
+                    return;
+                }
+
+                element._sortableInstance = window.Sortable.create(element, {
+                    animation: 150,
+                    ghostClass: 'workflow-state-ghost',
+                    onEnd: function () {
+                        $(element).trigger('states:reordered');
+                    }
+                });
+            });
+        },
+
+        initTinyMCE: function () {
+            if (typeof window.tinymce === 'undefined') {
+                return;
+            }
+
+            var selector = '#element-content';
+            var $textarea = $(selector);
+
+            if (!$textarea.length) {
+                return;
+            }
+
+            if (window.tinymce.get($textarea.attr('id'))) {
+                return;
+            }
+
+            window.tinymce.init({
+                selector: selector,
+                height: 360,
+                menubar: false,
+                branding: false,
+                plugins: 'link lists code',
+                toolbar: 'undo redo | bold italic underline | bullist numlist | link | code',
+                setup: function (editor) {
+                    editor.on('change keyup', function () {
+                        editor.save();
+                    });
+                }
+            });
+        },
+
+        initCodeMirror: function () {
+            if (typeof window.CodeMirror === 'undefined') {
+                return;
+            }
+
+            $('[data-role="code-editor"]').each(function () {
+                var textarea = this;
+
+                if ($(textarea).data('codemirrorInstance')) {
+                    return;
+                }
+
+                var editor = window.CodeMirror.fromTextArea(textarea, {
+                    mode: $(textarea).data('mode') || 'javascript',
+                    lineNumbers: true,
+                    readOnly: $(textarea).is('[readonly]') ? 'nocursor' : false
+                });
+
+                $(textarea).data('codemirrorInstance', editor);
+            });
         },
 
         selectRow: function ($row) {

--- a/src/Http/Dashboard/Views/elements/create.php
+++ b/src/Http/Dashboard/Views/elements/create.php
@@ -82,8 +82,21 @@ $this->params['breadcrumbs'][] = $this->title;
                             <button type="button" class="btn btn-box-tool" data-action="attach-media"><i class="fa fa-plus"></i></button>
                         </div>
                     </div>
-                    <div class="box-body text-muted small">
-                        Подключите изображения и документы из медиатеки.
+                    <div class="box-body">
+                        <form
+                            action="#"
+                            method="post"
+                            class="dropzone"
+                            enctype="multipart/form-data"
+                            data-role="media-dropzone"
+                        >
+                            <div class="dz-message">
+                                Перетащите файлы сюда или нажмите для загрузки превью и вложений.
+                            </div>
+                        </form>
+                        <p class="help-block text-muted small">
+                            Загрузка демонстрационная: файлы не отправляются на сервер, но область Dropzone уже доступна для интеграции.
+                        </p>
                     </div>
                 </div>
             </div>

--- a/src/Http/Dashboard/Views/integrations/graphql.php
+++ b/src/Http/Dashboard/Views/integrations/graphql.php
@@ -20,6 +20,12 @@ $this->params['breadcrumbs'][] = $this->title;
     </div>
     <div class="box-body">
         <p class="text-muted">Схема GraphQL будет сгенерирована автоматически. Здесь появится интерактивный Playground.</p>
-        <pre class="pre-scrollable" data-role="graphql-schema"># Schema preview will be available soon.</pre>
+        <textarea
+            class="form-control"
+            rows="12"
+            readonly
+            data-role="code-editor"
+            data-mode="javascript"
+        ># Schema preview will be available soon.</textarea>
     </div>
 </div>

--- a/src/Http/Dashboard/Views/workflow/states.php
+++ b/src/Http/Dashboard/Views/workflow/states.php
@@ -19,10 +19,20 @@ $this->params['breadcrumbs'][] = $this->title;
         </div>
     </div>
     <div class="box-body">
+        <p class="text-muted small">Перетащите статусы, чтобы изменить порядок переходов.</p>
         <div class="list-group" data-role="states-list">
-            <a href="#" class="list-group-item">Черновик</a>
-            <a href="#" class="list-group-item">На ревью</a>
-            <a href="#" class="list-group-item">Опубликовано</a>
+            <a href="#" class="list-group-item">
+                <span class="state-handle"><i class="fa fa-bars"></i></span>
+                Черновик
+            </a>
+            <a href="#" class="list-group-item">
+                <span class="state-handle"><i class="fa fa-bars"></i></span>
+                На ревью
+            </a>
+            <a href="#" class="list-group-item">
+                <span class="state-handle"><i class="fa fa-bars"></i></span>
+                Опубликовано
+            </a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- зарегистрированы дополнительные плагины AdminLTE для flatpickr, Dropzone, SortableJS, TinyMCE и CodeMirror
- добавлена инициализация новых виджетов в dashboard.js и стили для drag-and-drop/кодовых редакторов
- обновлены страницы создания элементов, управления статусами и GraphQL для использования новых компонентов

## Testing
- not run (тесты не требовались)


------
https://chatgpt.com/codex/tasks/task_e_68ccddb8ee3c832d96e6a279f5c21862