### PR TITLE
Переработка навигации дашборда согласно ТЗ

### DIFF
--- a/src/Http/Dashboard/Controllers/CollectionsController.php
+++ b/src/Http/Dashboard/Controllers/CollectionsController.php
@@ -22,4 +22,25 @@ final class CollectionsController extends Controller
     {
         return $this->render('create');
     }
+
+    public function actionEntries(?string $handle = null): string
+    {
+        return $this->render('entries', [
+            'handle' => $handle,
+        ]);
+    }
+
+    public function actionSavedViews(?string $handle = null): string
+    {
+        return $this->render('saved-views', [
+            'handle' => $handle,
+        ]);
+    }
+
+    public function actionSettings(?string $handle = null): string
+    {
+        return $this->render('settings', [
+            'handle' => $handle,
+        ]);
+    }
 }

--- a/src/Http/Dashboard/Controllers/SearchController.php
+++ b/src/Http/Dashboard/Controllers/SearchController.php
@@ -17,4 +17,9 @@ final class SearchController extends Controller
     {
         return $this->render('index');
     }
+
+    public function actionRebuild(): string
+    {
+        return $this->render('rebuild');
+    }
 }

--- a/src/Http/Dashboard/Controllers/SystemController.php
+++ b/src/Http/Dashboard/Controllers/SystemController.php
@@ -27,4 +27,9 @@ final class SystemController extends Controller
     {
         return $this->render('jobs');
     }
+
+    public function actionCache(): string
+    {
+        return $this->render('cache');
+    }
 }

--- a/src/Http/Dashboard/Views/collections/entries.php
+++ b/src/Http/Dashboard/Views/collections/entries.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+/* @var $handle string|null */
+
+$collectionLabel = $handle !== null && $handle !== '' ? $handle : 'не выбрана';
+
+$this->title = 'Записи коллекции';
+$this->params['breadcrumbs'][] = ['label' => 'Коллекции', 'url' => ['index']];
+if ($handle !== null && $handle !== '') {
+    $this->params['breadcrumbs'][] = $handle;
+}
+$this->params['breadcrumbs'][] = 'Записи';
+?>
+
+<div class="box box-primary" data-role="collection-entries">
+    <div class="box-header with-border">
+        <h3 class="box-title">Записи</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-success btn-sm" data-action="create-entry">
+                <i class="fa fa-plus"></i> Новая запись
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">
+            Текущая коллекция: <code><?= $collectionLabel ?></code>.
+            Список записей появится после выбора реальной коллекции.
+        </p>
+        <div class="table-responsive">
+            <table class="table table-hover" data-role="collection-entries-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Статус</th>
+                    <th class="hidden-xs">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="3" class="text-muted text-center">
+                        Записи появятся после выбора коллекции и добавления контента.
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/collections/saved-views.php
+++ b/src/Http/Dashboard/Views/collections/saved-views.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+/* @var $handle string|null */
+
+$collectionLabel = $handle !== null && $handle !== '' ? $handle : 'не выбрана';
+
+$this->title = 'Saved Views';
+$this->params['breadcrumbs'][] = ['label' => 'Коллекции', 'url' => ['index']];
+if ($handle !== null && $handle !== '') {
+    $this->params['breadcrumbs'][] = $handle;
+}
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="collection-saved-views">
+    <div class="box-header with-border">
+        <h3 class="box-title">Saved Views</h3>
+        <div class="box-tools">
+            <button type="button" class="btn btn-default btn-sm" data-action="create-saved-view">
+                <i class="fa fa-star"></i> Сохранить текущий фильтр
+            </button>
+        </div>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">
+            Текущая коллекция: <code><?= $collectionLabel ?></code>.
+            Здесь будут отображаться сохранённые представления списка записей.
+        </p>
+        <div class="table-responsive">
+            <table class="table table-striped" data-role="saved-views-table">
+                <thead>
+                <tr>
+                    <th>Название</th>
+                    <th class="hidden-xs">Автор</th>
+                    <th class="hidden-xs">Обновлено</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="empty">
+                    <td colspan="3" class="text-muted text-center">
+                        Saved Views появятся после сохранения первого представления.
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/collections/settings.php
+++ b/src/Http/Dashboard/Views/collections/settings.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+/* @var $handle string|null */
+
+$collectionLabel = $handle !== null && $handle !== '' ? $handle : 'не выбрана';
+
+$this->title = 'Настройки коллекции';
+$this->params['breadcrumbs'][] = ['label' => 'Коллекции', 'url' => ['index']];
+if ($handle !== null && $handle !== '') {
+    $this->params['breadcrumbs'][] = $handle;
+}
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-primary" data-role="collection-settings">
+    <div class="box-header with-border">
+        <h3 class="box-title">Настройки</h3>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">
+            Текущая коллекция: <code><?= $collectionLabel ?></code>.
+            Здесь будут расположены параметры отображения, публикации и разрешений коллекции.
+        </p>
+        <form class="form-horizontal" data-role="collection-settings-form">
+            <div class="form-group">
+                <label class="col-sm-3 control-label" for="collection-name">Название</label>
+                <div class="col-sm-9">
+                    <input type="text" id="collection-name" class="form-control" placeholder="Коллекция статей" value="<?= $handle ?>">
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label" for="collection-handle">Handle</label>
+                <div class="col-sm-9">
+                    <input type="text" id="collection-handle" class="form-control" placeholder="articles" value="<?= $handle ?>">
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label" for="collection-color">Цвет</label>
+                <div class="col-sm-9">
+                    <input type="color" id="collection-color" class="form-control" value="#3c8dbc">
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label" for="collection-layout">Layout по умолчанию</label>
+                <div class="col-sm-9">
+                    <select id="collection-layout" class="form-control select2">
+                        <option value="table">Таблица</option>
+                        <option value="cards">Карточки</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-3 col-sm-9">
+                    <button type="button" class="btn btn-primary" data-action="save-collection-settings">Сохранить изменения</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/layouts/left.php
+++ b/src/Http/Dashboard/Views/layouts/left.php
@@ -6,6 +6,31 @@ $requestedRoute = Yii::$app->requestedRoute ?? '';
 $equalsRoute = static fn(string $route): bool => $requestedRoute === ltrim($route, '/');
 $inSection = static fn(string $prefix): bool => str_starts_with($requestedRoute, ltrim($prefix, '/'));
 $caret = '<i class="fa fa-angle-left pull-right"></i>';
+$matchesAnyRoute = static function (array $routes) use ($equalsRoute): bool {
+    foreach ($routes as $route) {
+        if ($equalsRoute($route)) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+$collectionDetailActive = $matchesAnyRoute([
+    'dashboard/collections/entries',
+    'dashboard/collections/saved-views',
+    'dashboard/collections/settings',
+]);
+
+$workflowManagementActive = $matchesAnyRoute([
+    'dashboard/workflow/states',
+    'dashboard/workflow/transitions',
+]);
+
+$systemQueueActive = $matchesAnyRoute([
+    'dashboard/system/queue',
+    'dashboard/system/jobs',
+]);
 
 $menuItems = [
     '<li class="header">Главное</li>',
@@ -21,14 +46,32 @@ $menuItems = [
         'options' => ['class' => 'treeview'],
         'items' => [
             [
-                'label' => '<i class="fa fa-list"></i> Все коллекции',
+                'label' => '<i class="fa fa-list-ul"></i> Список коллекций',
                 'url' => Url::to(['/dashboard/collections/index']),
                 'active' => $equalsRoute('dashboard/collections/index'),
             ],
             [
-                'label' => '<i class="fa fa-plus-circle"></i> Новая коллекция',
-                'url' => Url::to(['/dashboard/collections/create']),
-                'active' => $equalsRoute('dashboard/collections/create'),
+                'label' => '<i class="fa fa-folder"></i> <span>Коллекция: {handle}</span>' . $caret,
+                'url' => '#',
+                'options' => ['class' => 'treeview'],
+                'items' => [
+                    [
+                        'label' => '<i class="fa fa-file-text-o"></i> Записи',
+                        'url' => Url::to(['/dashboard/collections/entries']),
+                        'active' => $equalsRoute('dashboard/collections/entries'),
+                    ],
+                    [
+                        'label' => '<i class="fa fa-eye"></i> Saved Views',
+                        'url' => Url::to(['/dashboard/collections/saved-views']),
+                        'active' => $equalsRoute('dashboard/collections/saved-views'),
+                    ],
+                    [
+                        'label' => '<i class="fa fa-sliders"></i> Настройки коллекции',
+                        'url' => Url::to(['/dashboard/collections/settings']),
+                        'active' => $equalsRoute('dashboard/collections/settings'),
+                    ],
+                ],
+                'active' => $collectionDetailActive,
             ],
         ],
         'active' => $inSection('dashboard/collections'),
@@ -165,7 +208,7 @@ $menuItems = [
     ],
     '<li class="header">Расширения</li>',
     [
-        'label' => '<i class="fa fa-plug"></i> <span>Плагины</span>' . $caret,
+        'label' => '<i class="fa fa-puzzle-piece"></i> <span>Плагины</span>' . $caret,
         'url' => Url::to(['/dashboard/plugins/index']),
         'options' => ['class' => 'treeview'],
         'items' => [
@@ -188,7 +231,7 @@ $menuItems = [
         'active' => $inSection('dashboard/plugins'),
     ],
     [
-        'label' => '<i class="fa fa-exchange"></i> <span>Интеграции</span>' . $caret,
+        'label' => '<i class="fa fa-plug"></i> <span>Интеграции</span>' . $caret,
         'url' => Url::to(['/dashboard/integrations/index']),
         'options' => ['class' => 'treeview'],
         'items' => [
@@ -198,7 +241,7 @@ $menuItems = [
                 'active' => $equalsRoute('dashboard/integrations/rest'),
             ],
             [
-                'label' => '<i class="fa fa-code"></i> GraphQL',
+                'label' => '<i class="fa fa-code-fork"></i> GraphQL',
                 'url' => Url::to(['/dashboard/integrations/graphql']),
                 'active' => $equalsRoute('dashboard/integrations/graphql'),
             ],
@@ -217,9 +260,40 @@ $menuItems = [
         'active' => $inSection('dashboard/localization'),
     ],
     [
-        'label' => '<i class="fa fa-random"></i> <span>Воркфлоу</span>',
+        'label' => '<i class="fa fa-random"></i> <span>Workflow</span>' . $caret,
         'url' => Url::to(['/dashboard/workflow/index']),
+        'options' => ['class' => 'treeview'],
+        'items' => [
+            [
+                'label' => '<i class="fa fa-check-square-o"></i> Задачи на ревью',
+                'url' => Url::to(['/dashboard/workflow/index']),
+                'active' => $equalsRoute('dashboard/workflow/index'),
+            ],
+            [
+                'label' => '<i class="fa fa-code-fork"></i> Версии и сравнения',
+                'url' => Url::to(['/dashboard/workflow/transitions']),
+                'active' => $workflowManagementActive,
+            ],
+        ],
         'active' => $inSection('dashboard/workflow'),
+    ],
+    [
+        'label' => '<i class="fa fa-search"></i> <span>Поиск</span>' . $caret,
+        'url' => Url::to(['/dashboard/search/index']),
+        'options' => ['class' => 'treeview'],
+        'items' => [
+            [
+                'label' => '<i class="fa fa-database"></i> Индексы',
+                'url' => Url::to(['/dashboard/search/index']),
+                'active' => $equalsRoute('dashboard/search/index'),
+            ],
+            [
+                'label' => '<i class="fa fa-refresh"></i> Перестроить',
+                'url' => Url::to(['/dashboard/search/rebuild']),
+                'active' => $equalsRoute('dashboard/search/rebuild'),
+            ],
+        ],
+        'active' => $inSection('dashboard/search'),
     ],
     '<li class="header">Система</li>',
     [
@@ -246,19 +320,27 @@ $menuItems = [
         'active' => $inSection('dashboard/settings'),
     ],
     [
-        'label' => '<i class="fa fa-list-ul"></i> <span>Журналы</span>',
-        'url' => Url::to(['/dashboard/system/logs']),
-        'active' => $inSection('dashboard/system/logs'),
-    ],
-    [
-        'label' => '<i class="fa fa-tasks"></i> <span>Очереди</span>',
+        'label' => '<i class="fa fa-server"></i> <span>Обслуживание</span>' . $caret,
         'url' => Url::to(['/dashboard/system/queue']),
-        'active' => $inSection('dashboard/system/queue'),
-    ],
-    [
-        'label' => '<i class="fa fa-server"></i> <span>Фоновые задачи</span>',
-        'url' => Url::to(['/dashboard/system/jobs']),
-        'active' => $inSection('dashboard/system/jobs'),
+        'options' => ['class' => 'treeview'],
+        'items' => [
+            [
+                'label' => '<i class="fa fa-tasks"></i> Очереди и задания',
+                'url' => Url::to(['/dashboard/system/queue']),
+                'active' => $systemQueueActive,
+            ],
+            [
+                'label' => '<i class="fa fa-eraser"></i> Кэш и очистка',
+                'url' => Url::to(['/dashboard/system/cache']),
+                'active' => $equalsRoute('dashboard/system/cache'),
+            ],
+            [
+                'label' => '<i class="fa fa-list-ul"></i> Логи и аудит',
+                'url' => Url::to(['/dashboard/system/logs']),
+                'active' => $equalsRoute('dashboard/system/logs'),
+            ],
+        ],
+        'active' => $inSection('dashboard/system'),
     ],
 ];
 

--- a/src/Http/Dashboard/Views/search/rebuild.php
+++ b/src/Http/Dashboard/Views/search/rebuild.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Перестроить поиск';
+$this->params['breadcrumbs'][] = ['label' => 'Поиск', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-warning" data-role="search-rebuild">
+    <div class="box-header with-border">
+        <h3 class="box-title">Перестроение индексов</h3>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">
+            Используйте этот раздел, чтобы вручную обновить поисковые индексы после крупных изменений контента.
+        </p>
+        <div class="form-group">
+            <label for="rebuild-scope">Область перестроения</label>
+            <select id="rebuild-scope" class="form-control select2">
+                <option value="all">Все коллекции</option>
+                <option value="changed">Только обновлённые записи</option>
+                <option value="custom">Выбрать коллекции вручную</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="rebuild-notify">Уведомить</label>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" id="rebuild-notify" checked>
+                    Отправить уведомление команде после завершения
+                </label>
+            </div>
+        </div>
+        <div class="progress" style="display: none;" data-role="rebuild-progress">
+            <div class="progress-bar progress-bar-striped active" style="width: 0%;"></div>
+        </div>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-warning" data-action="start-rebuild">
+            <i class="fa fa-refresh"></i> Запустить перестроение
+        </button>
+    </div>
+</div>

--- a/src/Http/Dashboard/Views/system/cache.php
+++ b/src/Http/Dashboard/Views/system/cache.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\web\View */
+
+$this->title = 'Кэш и очистка';
+$this->params['breadcrumbs'][] = ['label' => 'Система', 'url' => ['logs']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="box box-info" data-role="system-cache">
+    <div class="box-header with-border">
+        <h3 class="box-title">Управление кэшем</h3>
+    </div>
+    <div class="box-body">
+        <p class="text-muted">
+            Очистите кэш, чтобы обновить данные после изменений конфигурации или миграций.
+        </p>
+        <div class="row">
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="cache-segment">Сегмент кэша</label>
+                    <select id="cache-segment" class="form-control select2">
+                        <option value="all">Весь кэш</option>
+                        <option value="config">Конфигурация</option>
+                        <option value="templates">Шаблоны</option>
+                        <option value="assets">Файлы и ассеты</option>
+                    </select>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="cache-warmup">Разогреть после очистки</label>
+                    <select id="cache-warmup" class="form-control select2">
+                        <option value="none">Не разогревать</option>
+                        <option value="critical">Только критические страницы</option>
+                        <option value="full">Полный разогрев</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" data-role="cache-backup" checked>
+                Создать резервную копию перед очисткой
+            </label>
+        </div>
+    </div>
+    <div class="box-footer text-right">
+        <button type="button" class="btn btn-default" data-action="preview-cache-clear">
+            <i class="fa fa-search"></i> Предпросмотр
+        </button>
+        <button type="button" class="btn btn-danger" data-action="clear-cache">
+            <i class="fa fa-trash"></i> Очистить кэш
+        </button>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Перестроил структуру бокового меню: добавил вспомогательный `matchesAnyRoute`, обновил порядок разделов, иконки и вложенность, включая новую ветку «Коллекция: {handle}», разделы «Поиск» и «Обслуживание».
- Добавил действия контроллера коллекций и представления-заглушки для «Записи», «Saved Views» и «Настройки коллекции», чтобы новые ссылки меню вели на существующие страницы.
- Расширил разделы поиска и системы маршрутами и шаблонами для «Перестроить» и «Кэш и очистка».

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cce09f0c4c832d81a259c76d9a7fc2