### PR TITLE
feat: enhance dashboard relations, media picker and taxonomy tree

### DIFF
--- a/src/Http/Dashboard/Assets/dist/css/dashboard.css
+++ b/src/Http/Dashboard/Assets/dist/css/dashboard.css
@@ -155,3 +155,191 @@ h1, h2, h3, h4, h5, h6 {
 .matrix--filled .matrix__empty {
   display: none;
 }
+
+.relation-select-option {
+  padding: 6px 8px;
+}
+
+.relation-select-option__title {
+  font-weight: 600;
+  color: #333333;
+}
+
+.relation-select-option__meta {
+  margin-top: 2px;
+  font-size: 12px;
+  color: #8a8f98;
+}
+
+.media-library__results {
+  position: relative;
+  min-height: 140px;
+}
+
+.media-library__col {
+  margin-bottom: 20px;
+}
+
+.media-library__item {
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  border: 1px solid #e3e6eb;
+  border-radius: 4px;
+  background-color: #ffffff;
+}
+
+.media-library__item.thumbnail {
+  padding: 0;
+}
+
+.media-library__preview {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 160px;
+  background-color: #f7f9fb;
+  border-bottom: 1px solid #edf1f5;
+  overflow: hidden;
+}
+
+.media-library__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.media-library__icon {
+  font-size: 36px;
+  color: #9ea3aa;
+}
+
+.media-library__caption {
+  padding: 10px 12px;
+}
+
+.media-library__title {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #333333;
+}
+
+.media-library__meta {
+  font-size: 12px;
+  color: #8a8f98;
+}
+
+.media-library__item--selected {
+  border-color: #3c8dbc;
+  box-shadow: 0 0 0 2px rgba(60, 141, 188, 0.25);
+}
+
+.media-library__item--selected .media-library__preview::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-color: rgba(60, 141, 188, 0.15);
+}
+
+.media-library__list {
+  border: 1px solid #e3e6eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.media-library__list-item {
+  padding: 10px 12px;
+  border-bottom: 1px solid #eef1f4;
+  transition: background-color 0.2s ease;
+}
+
+.media-library__list-item:last-child {
+  border-bottom: none;
+}
+
+.media-library__list-item.media-library__item--selected {
+  background-color: #f1f7fd;
+}
+
+.media-library__list-title {
+  font-weight: 600;
+  color: #333333;
+}
+
+.media-library__list-meta {
+  font-size: 12px;
+  color: #8a8f98;
+  margin-top: 2px;
+}
+
+.taxonomy-term-card {
+  border: 1px solid #e3e6eb;
+  border-radius: 4px;
+  padding: 8px 12px;
+  background-color: #ffffff;
+  margin-bottom: 8px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.03);
+}
+
+.taxonomy-term-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.taxonomy-term-card__handle {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  color: #9ea3aa;
+  cursor: move;
+}
+
+.taxonomy-term-card__labels {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.taxonomy-term-card__title {
+  font-weight: 600;
+  color: #333333;
+}
+
+.taxonomy-term-card__slug {
+  font-size: 12px;
+  color: #9ea3aa;
+}
+
+.taxonomy-term-card__badge {
+  margin-left: auto;
+  background-color: #d2d6de;
+}
+
+.taxonomy-term-card__description {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #7a7f87;
+}
+
+.taxonomy-term-card--match {
+  border-color: #3c8dbc;
+  box-shadow: 0 0 0 1px rgba(60, 141, 188, 0.25);
+}
+
+.taxonomy-term-card--ghost {
+  opacity: 0.7;
+  border-style: dashed;
+}
+
+.taxonomy-term-children {
+  margin-left: 24px;
+  padding-left: 0;
+}
+
+.taxonomy-term-item:last-child > .taxonomy-term-card {
+  margin-bottom: 0;
+}

--- a/src/Http/Dashboard/Views/media/library.php
+++ b/src/Http/Dashboard/Views/media/library.php
@@ -19,7 +19,7 @@ $this->params['breadcrumbs'][] = $this->title;
                     'class' => 'btn btn-success',
                     'data-pjax' => '0',
                 ]) ?>
-                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#media-filters">
+                <button type="button" class="btn btn-default" data-action="toggle-media-filters">
                     <i class="fa fa-filter"></i>
                 </button>
                 <button type="button" class="btn btn-default" data-action="refresh-library">
@@ -29,42 +29,65 @@ $this->params['breadcrumbs'][] = $this->title;
         </div>
     </div>
     <div class="box-body">
-        <div class="row margin-bottom">
-            <div class="col-sm-6">
+        <div class="row margin-bottom" data-role="media-toolbar">
+            <div class="col-sm-4">
                 <div class="input-group input-group-sm">
                     <span class="input-group-addon"><i class="fa fa-search"></i></span>
                     <input type="search" class="form-control" placeholder="Поиск по названию или тегам" data-role="media-search">
                 </div>
             </div>
-            <div class="col-sm-6 text-right">
+            <div class="col-sm-8 text-right">
                 <div class="btn-group btn-group-sm" data-role="media-view-mode">
                     <button type="button" class="btn btn-default active" data-mode="grid"><i class="fa fa-th"></i></button>
                     <button type="button" class="btn btn-default" data-mode="list"><i class="fa fa-list"></i></button>
                 </div>
             </div>
         </div>
-        <div class="row" data-role="media-grid">
+        <div class="row margin-bottom media-filters-row" data-role="media-filters-panel">
             <div class="col-sm-3">
-                <div class="thumbnail">
-                    <img src="https://via.placeholder.com/300x200?text=Preview" alt="Preview">
-                    <div class="caption">
-                        <h5>demo.jpg</h5>
-                        <p class="small text-muted">Размер 1.2 МБ</p>
-                        <p>
-                            <button type="button" class="btn btn-primary btn-xs" data-action="choose-file">Выбрать</button>
-                            <button type="button" class="btn btn-default btn-xs" data-action="details">Подробнее</button>
-                        </p>
-                    </div>
-                </div>
+                <label for="media-type" class="control-label small text-muted">Тип файла</label>
+                <select id="media-type"
+                        class="form-control input-sm select2"
+                        data-role="media-filter-type"
+                        data-placeholder="Все типы"></select>
             </div>
             <div class="col-sm-3">
-                <div class="thumbnail placeholder">
-                    <div class="caption text-center text-muted">
-                        <i class="fa fa-picture-o fa-3x"></i>
-                        <p>Новые файлы появятся после загрузки.</p>
-                    </div>
-                </div>
+                <label for="media-collection" class="control-label small text-muted">Коллекция</label>
+                <select id="media-collection"
+                        class="form-control input-sm select2"
+                        data-role="media-filter-collection"
+                        data-placeholder="Все коллекции"></select>
             </div>
+            <div class="col-sm-3">
+                <label for="media-tags" class="control-label small text-muted">Теги</label>
+                <select id="media-tags"
+                        class="form-control input-sm select2"
+                        data-role="media-filter-tags"
+                        data-placeholder="Теги"
+                        multiple></select>
+            </div>
+            <div class="col-sm-3">
+                <label for="media-period" class="control-label small text-muted">Период</label>
+                <select id="media-period"
+                        class="form-control input-sm select2"
+                        data-role="media-filter-period">
+                    <option value="30">За 30 дней</option>
+                    <option value="90">За 90 дней</option>
+                    <option value="180">За полгода</option>
+                    <option value="365">За год</option>
+                    <option value="all">За всё время</option>
+                </select>
+            </div>
+        </div>
+        <div class="media-library__results" data-role="media-results">
+            <div class="alert alert-info" data-role="media-loading" style="display: none;">
+                Загружаем медиатеку…
+            </div>
+            <div class="alert alert-warning" data-role="media-empty" style="display: none;">
+                По заданным условиям ничего не найдено. Попробуйте изменить фильтры или поиск.
+            </div>
+            <div class="row media-library__items" data-role="media-items"></div>
+            <div class="media-library__list" data-role="media-list" style="display: none;"></div>
         </div>
     </div>
     <div class="box-footer clearfix">
@@ -75,43 +98,14 @@ $this->params['breadcrumbs'][] = $this->title;
             <button type="button" class="btn btn-default btn-sm" data-action="clear-selection">Сбросить выбор</button>
             <button type="button" class="btn btn-primary btn-sm" data-action="insert-selection">Использовать</button>
         </div>
-    </div>
-</div>
-
-<div class="modal fade" id="media-filters" tabindex="-1" role="dialog" aria-labelledby="media-filters-label">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="media-filters-label">Фильтры медиатеки</h4>
+        <div class="clearfix"></div>
+        <form data-role="media-selection-form" class="media-selection-form">
+            <input type="hidden" name="media_selection" data-role="media-selection-input">
+            <div class="form-group" style="margin-top: 12px;">
+                <label class="control-label">Выбранные ассеты (JSON)</label>
+                <textarea class="form-control input-sm" rows="4" readonly data-role="media-selection-output"></textarea>
+                <p class="help-block" data-role="media-selection-feedback"></p>
             </div>
-            <div class="modal-body">
-                <div class="form-group">
-                    <label for="media-type" class="control-label">Тип файла</label>
-                    <select id="media-type" class="form-control select2">
-                        <option value="">Все</option>
-                        <option value="image">Изображения</option>
-                        <option value="video">Видео</option>
-                        <option value="audio">Аудио</option>
-                        <option value="document">Документы</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label for="media-period" class="control-label">Период загрузки</label>
-                    <select id="media-period" class="form-control">
-                        <option value="30">За 30 дней</option>
-                        <option value="90">За 90 дней</option>
-                        <option value="all">За всё время</option>
-                    </select>
-                </div>
-                <div class="checkbox">
-                    <label><input type="checkbox"> Показать только несвязанные файлы</label>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Отмена</button>
-                <button type="button" class="btn btn-primary" data-action="apply-media-filters">Применить</button>
-            </div>
-        </div>
+        </form>
     </div>
 </div>

--- a/src/Http/Dashboard/Views/relations/index.php
+++ b/src/Http/Dashboard/Views/relations/index.php
@@ -64,11 +64,19 @@ $this->params['breadcrumbs'][] = $this->title;
                     </div>
                     <div class="form-group">
                         <label for="relation-source">Источник</label>
-                        <select id="relation-source" class="form-control select2"></select>
+                        <select id="relation-source"
+                                class="form-control select2"
+                                data-role="relation-source"
+                                data-placeholder="Выберите элемент-источник"
+                                data-skip-global-init="true"></select>
                     </div>
                     <div class="form-group">
                         <label for="relation-target">Получатель</label>
-                        <select id="relation-target" class="form-control select2"></select>
+                        <select id="relation-target"
+                                class="form-control select2"
+                                data-role="relation-target"
+                                data-placeholder="Выберите элемент-получатель"
+                                data-skip-global-init="true"></select>
                     </div>
                 </form>
             </div>

--- a/src/Http/Dashboard/Views/taxonomies/terms.php
+++ b/src/Http/Dashboard/Views/taxonomies/terms.php
@@ -34,32 +34,24 @@ $this->params['breadcrumbs'][] = $this->title;
                 </div>
             </div>
             <div class="col-sm-6 text-right">
-                <select class="form-control input-sm" data-role="taxonomy-filter" style="max-width: 220px;">
-                    <option value="">Все таксономии</option>
+                <select class="form-control input-sm select2"
+                        data-role="taxonomy-filter"
+                        data-placeholder="Выберите таксономию"
+                        style="max-width: 260px;">
                 </select>
             </div>
         </div>
-        <div class="table-responsive">
-            <table class="table table-striped" data-role="terms-table">
-                <thead>
-                <tr>
-                    <th>Название</th>
-                    <th class="hidden-xs">Слаг</th>
-                    <th class="hidden-xs">Таксономия</th>
-                    <th style="width: 120px;" class="hidden-xs">Использований</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr class="empty">
-                    <td colspan="4" class="text-center text-muted">Список терминов пуст.</td>
-                </tr>
-                </tbody>
-            </table>
+        <div class="taxonomy-terms-tree" data-role="terms-panel">
+            <div class="alert alert-info" data-role="terms-empty">
+                Выберите таксономию или измените условия поиска, чтобы увидеть дерево терминов.
+            </div>
+            <ul class="list-unstyled" data-role="terms-tree"></ul>
         </div>
+        <p class="help-block" data-role="terms-feedback"></p>
     </div>
     <div class="box-footer clearfix">
-        <div class="pull-left text-muted small">
-            Используйте drag-n-drop для изменения иерархии (будет доступно позже).
+        <div class="pull-left text-muted small" data-role="terms-summary">
+            Перетаскивайте термины для изменения порядка и вложенности. Поиск работает по названию и слагу.
         </div>
         <div class="pull-right">
             <?= Html::a('<i class="fa fa-angle-left"></i> К таксономиям', ['index'], [


### PR DESCRIPTION
## Summary
- integrate relation modal selects with Select2 AJAX lookup and persisted selections
- turn the media library page into an interactive asset picker with filters, multi-select and JSON output
- add a sortable taxonomy tree with search, Select2 filtering and supportive styling updates

## Testing
- `composer test` *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb98dd7e8832daf6244e4efc2419b