### PR TITLE
Integrate workflow transitions with element state changes

### DIFF
--- a/migrations/m250925_130000_create_workflow_tables.php
+++ b/migrations/m250925_130000_create_workflow_tables.php
@@ -1,0 +1,263 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+use yii\db\Migration;
+
+final class m250925_130000_create_workflow_tables extends Migration
+{
+    public function safeUp(): void
+    {
+        $this->createTable('{{%workflow}}', [
+            'id' => $this->primaryKey(),
+            'uid' => $this->char(32)->notNull(),
+            'handle' => $this->string(64)->notNull(),
+            'name' => $this->string(128)->notNull(),
+            'description' => $this->text()->null(),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_workflow_uid', '{{%workflow}}', 'uid', true);
+        $this->createIndex('ux_workflow_handle', '{{%workflow}}', 'handle', true);
+
+        $this->createTable('{{%workflow_state}}', [
+            'id' => $this->primaryKey(),
+            'uid' => $this->char(32)->notNull(),
+            'workflow_id' => $this->integer()->notNull(),
+            'handle' => $this->string(64)->notNull(),
+            'name' => $this->string(128)->notNull(),
+            'type' => $this->string(32)->notNull(),
+            'color' => $this->string(16)->notNull()->defaultValue('#3c8dbc'),
+            'is_initial' => $this->boolean()->notNull()->defaultValue(false),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_workflow_state_uid', '{{%workflow_state}}', 'uid', true);
+        $this->createIndex('ux_workflow_state_handle', '{{%workflow_state}}', ['workflow_id', 'handle'], true);
+        $this->createIndex('idx_workflow_state_workflow', '{{%workflow_state}}', 'workflow_id');
+        $this->addForeignKey(
+            'fk_workflow_state_workflow',
+            '{{%workflow_state}}',
+            'workflow_id',
+            '{{%workflow}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+
+        $this->createTable('{{%workflow_transition}}', [
+            'id' => $this->primaryKey(),
+            'uid' => $this->char(32)->notNull(),
+            'workflow_id' => $this->integer()->notNull(),
+            'name' => $this->string(128)->notNull(),
+            'from_state_id' => $this->integer()->notNull(),
+            'to_state_id' => $this->integer()->notNull(),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('ux_workflow_transition_uid', '{{%workflow_transition}}', 'uid', true);
+        $this->createIndex('idx_workflow_transition_workflow', '{{%workflow_transition}}', 'workflow_id');
+        $this->createIndex('idx_workflow_transition_from', '{{%workflow_transition}}', 'from_state_id');
+        $this->createIndex('idx_workflow_transition_to', '{{%workflow_transition}}', 'to_state_id');
+        $this->addForeignKey(
+            'fk_workflow_transition_workflow',
+            '{{%workflow_transition}}',
+            'workflow_id',
+            '{{%workflow}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+        $this->addForeignKey(
+            'fk_workflow_transition_from',
+            '{{%workflow_transition}}',
+            'from_state_id',
+            '{{%workflow_state}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+        $this->addForeignKey(
+            'fk_workflow_transition_to',
+            '{{%workflow_transition}}',
+            'to_state_id',
+            '{{%workflow_state}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+
+        $this->createTable('{{%workflow_transition_role}}', [
+            'id' => $this->primaryKey(),
+            'transition_id' => $this->integer()->notNull(),
+            'role' => $this->string(64)->notNull(),
+        ]);
+        $this->createIndex('idx_workflow_transition_role_transition', '{{%workflow_transition_role}}', 'transition_id');
+        $this->createIndex(
+            'ux_workflow_transition_role_unique',
+            '{{%workflow_transition_role}}',
+            ['transition_id', 'role'],
+            true
+        );
+        $this->addForeignKey(
+            'fk_workflow_transition_role_transition',
+            '{{%workflow_transition_role}}',
+            'transition_id',
+            '{{%workflow_transition}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+
+        $this->addColumn('{{%element}}', 'workflow_state_id', $this->integer()->null());
+        $this->createIndex('idx_element_workflow_state', '{{%element}}', 'workflow_state_id');
+        $this->addForeignKey(
+            'fk_element_workflow_state',
+            '{{%element}}',
+            'workflow_state_id',
+            '{{%workflow_state}}',
+            'id',
+            'SET NULL',
+            'CASCADE'
+        );
+
+        $this->seedDefaultWorkflow();
+    }
+
+    public function safeDown(): void
+    {
+        $this->dropForeignKey('fk_element_workflow_state', '{{%element}}');
+        $this->dropIndex('idx_element_workflow_state', '{{%element}}');
+        $this->dropColumn('{{%element}}', 'workflow_state_id');
+
+        $this->dropForeignKey('fk_workflow_transition_role_transition', '{{%workflow_transition_role}}');
+        $this->dropTable('{{%workflow_transition_role}}');
+
+        $this->dropForeignKey('fk_workflow_transition_to', '{{%workflow_transition}}');
+        $this->dropForeignKey('fk_workflow_transition_from', '{{%workflow_transition}}');
+        $this->dropForeignKey('fk_workflow_transition_workflow', '{{%workflow_transition}}');
+        $this->dropIndex('idx_workflow_transition_to', '{{%workflow_transition}}');
+        $this->dropIndex('idx_workflow_transition_from', '{{%workflow_transition}}');
+        $this->dropIndex('idx_workflow_transition_workflow', '{{%workflow_transition}}');
+        $this->dropIndex('ux_workflow_transition_uid', '{{%workflow_transition}}');
+        $this->dropTable('{{%workflow_transition}}');
+
+        $this->dropForeignKey('fk_workflow_state_workflow', '{{%workflow_state}}');
+        $this->dropIndex('idx_workflow_state_workflow', '{{%workflow_state}}');
+        $this->dropIndex('ux_workflow_state_handle', '{{%workflow_state}}');
+        $this->dropIndex('ux_workflow_state_uid', '{{%workflow_state}}');
+        $this->dropTable('{{%workflow_state}}');
+
+        $this->dropIndex('ux_workflow_handle', '{{%workflow}}');
+        $this->dropIndex('ux_workflow_uid', '{{%workflow}}');
+        $this->dropTable('{{%workflow}}');
+    }
+
+    private function seedDefaultWorkflow(): void
+    {
+        $timestamp = time();
+        $workflowUid = bin2hex(random_bytes(16));
+        $this->insert('{{%workflow}}', [
+            'uid' => $workflowUid,
+            'handle' => 'default',
+            'name' => 'Стандартный процесс',
+            'description' => 'Базовая схема согласования контента.',
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+        $workflowId = (int) $this->db->getLastInsertID();
+
+        $states = [
+            [
+                'handle' => 'draft',
+                'name' => 'Черновик',
+                'type' => 'draft',
+                'color' => '#d2d6de',
+                'is_initial' => true,
+                'position' => 1,
+            ],
+            [
+                'handle' => 'review',
+                'name' => 'На ревью',
+                'type' => 'review',
+                'color' => '#f39c12',
+                'is_initial' => false,
+                'position' => 2,
+            ],
+            [
+                'handle' => 'published',
+                'name' => 'Опубликовано',
+                'type' => 'published',
+                'color' => '#00a65a',
+                'is_initial' => false,
+                'position' => 3,
+            ],
+        ];
+
+        $stateIds = [];
+        foreach ($states as $state) {
+            $uid = bin2hex(random_bytes(16));
+            $this->insert('{{%workflow_state}}', [
+                'uid' => $uid,
+                'workflow_id' => $workflowId,
+                'handle' => $state['handle'],
+                'name' => $state['name'],
+                'type' => $state['type'],
+                'color' => $state['color'],
+                'is_initial' => $state['is_initial'],
+                'position' => $state['position'],
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ]);
+            $stateIds[$state['handle']] = (int) $this->db->getLastInsertID();
+        }
+
+        $transitions = [
+            [
+                'name' => 'На ревью',
+                'from' => 'draft',
+                'to' => 'review',
+                'roles' => ['author', 'editor'],
+            ],
+            [
+                'name' => 'Вернуть в работу',
+                'from' => 'review',
+                'to' => 'draft',
+                'roles' => ['editor'],
+            ],
+            [
+                'name' => 'Опубликовать',
+                'from' => 'review',
+                'to' => 'published',
+                'roles' => ['editor', 'publisher'],
+            ],
+        ];
+
+        foreach ($transitions as $transition) {
+            $uid = bin2hex(random_bytes(16));
+            $this->insert('{{%workflow_transition}}', [
+                'uid' => $uid,
+                'workflow_id' => $workflowId,
+                'name' => $transition['name'],
+                'from_state_id' => $stateIds[$transition['from']] ?? null,
+                'to_state_id' => $stateIds[$transition['to']] ?? null,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ]);
+
+            $transitionId = (int) $this->db->getLastInsertID();
+            foreach ($transition['roles'] as $role) {
+                $this->insert('{{%workflow_transition_role}}', [
+                    'transition_id' => $transitionId,
+                    'role' => $role,
+                ]);
+            }
+        }
+    }
+}

--- a/src/Contracts/Workflow/WorkflowRepositoryInterface.php
+++ b/src/Contracts/Workflow/WorkflowRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Workflow;
+
+use Setka\Cms\Domain\Workflow\Workflow;
+
+interface WorkflowRepositoryInterface
+{
+    public function findById(int $id): ?Workflow;
+
+    public function findDefault(): ?Workflow;
+
+    public function save(Workflow $workflow): void;
+}

--- a/src/Contracts/Workflow/WorkflowStateRepositoryInterface.php
+++ b/src/Contracts/Workflow/WorkflowStateRepositoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Workflow;
+
+use Setka\Cms\Domain\Workflow\Workflow;
+use Setka\Cms\Domain\Workflow\WorkflowState;
+
+interface WorkflowStateRepositoryInterface
+{
+    /**
+     * @return WorkflowState[]
+     */
+    public function findByWorkflow(Workflow $workflow): array;
+
+    public function findById(Workflow $workflow, int $id): ?WorkflowState;
+
+    public function save(WorkflowState $state): void;
+
+    public function delete(Workflow $workflow, int $id): void;
+
+    /**
+     * @param int[] $orderedIds
+     */
+    public function reorder(Workflow $workflow, array $orderedIds): void;
+}

--- a/src/Contracts/Workflow/WorkflowTransitionRepositoryInterface.php
+++ b/src/Contracts/Workflow/WorkflowTransitionRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Contracts\Workflow;
+
+use Setka\Cms\Domain\Workflow\Workflow;
+use Setka\Cms\Domain\Workflow\WorkflowTransition;
+
+interface WorkflowTransitionRepositoryInterface
+{
+    /**
+     * @return WorkflowTransition[]
+     */
+    public function findByWorkflow(Workflow $workflow): array;
+
+    public function findById(Workflow $workflow, int $id): ?WorkflowTransition;
+
+    public function save(WorkflowTransition $transition): void;
+
+    public function delete(Workflow $workflow, int $id): void;
+}

--- a/src/Domain/Workflow/Workflow.php
+++ b/src/Domain/Workflow/Workflow.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Workflow;
+
+use DateTimeImmutable;
+
+final class Workflow
+{
+    private ?int $id;
+
+    private string $uid;
+
+    private string $handle;
+
+    private string $name;
+
+    private string $description;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $handle,
+        string $name,
+        string $description = '',
+        ?int $id = null,
+        ?string $uid = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null
+    ) {
+        $this->handle = $handle;
+        $this->name = $name;
+        $this->description = $description;
+        $this->id = $id;
+        $this->uid = $uid ?? bin2hex(random_bytes(16));
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+        $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function getHandle(): string
+    {
+        return $this->handle;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function markPersisted(
+        int $id,
+        ?string $uid = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null
+    ): void {
+        $this->id = $id;
+
+        if ($uid !== null && $uid !== '') {
+            $this->uid = $uid;
+        }
+
+        if ($createdAt !== null) {
+            $this->createdAt = $createdAt;
+        }
+
+        if ($updatedAt !== null) {
+            $this->updatedAt = $updatedAt;
+        }
+    }
+}

--- a/src/Domain/Workflow/WorkflowState.php
+++ b/src/Domain/Workflow/WorkflowState.php
@@ -1,0 +1,196 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Workflow;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+final class WorkflowState
+{
+    private ?int $id;
+
+    private string $uid;
+
+    private Workflow $workflow;
+
+    private string $handle;
+
+    private string $name;
+
+    private WorkflowStateType $type;
+
+    private string $color;
+
+    private bool $initial;
+
+    private int $position;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Workflow $workflow,
+        string $handle,
+        string $name,
+        WorkflowStateType $type,
+        string $color = '#3c8dbc',
+        bool $initial = false,
+        int $position = 0,
+        ?int $id = null,
+        ?string $uid = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null
+    ) {
+        if ($handle === '') {
+            throw new InvalidArgumentException('Workflow state handle can not be empty.');
+        }
+
+        if ($name === '') {
+            throw new InvalidArgumentException('Workflow state name can not be empty.');
+        }
+
+        $this->workflow = $workflow;
+        $this->handle = $handle;
+        $this->name = $name;
+        $this->type = $type;
+        $this->color = $color;
+        $this->initial = $initial;
+        $this->position = $position;
+        $this->id = $id;
+        $this->uid = $uid ?? bin2hex(random_bytes(16));
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+        $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
+    }
+
+    public function getWorkflow(): Workflow
+    {
+        return $this->workflow;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function getHandle(): string
+    {
+        return $this->handle;
+    }
+
+    public function setHandle(string $handle): void
+    {
+        if ($handle === '') {
+            throw new InvalidArgumentException('Workflow state handle can not be empty.');
+        }
+
+        $this->handle = $handle;
+        $this->touch();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        if ($name === '') {
+            throw new InvalidArgumentException('Workflow state name can not be empty.');
+        }
+
+        $this->name = $name;
+        $this->touch();
+    }
+
+    public function getType(): WorkflowStateType
+    {
+        return $this->type;
+    }
+
+    public function setType(WorkflowStateType $type): void
+    {
+        if ($this->type === $type) {
+            return;
+        }
+
+        $this->type = $type;
+        $this->touch();
+    }
+
+    public function getColor(): string
+    {
+        return $this->color;
+    }
+
+    public function setColor(string $color): void
+    {
+        $this->color = $color;
+        $this->touch();
+    }
+
+    public function isInitial(): bool
+    {
+        return $this->initial;
+    }
+
+    public function markInitial(bool $initial = true): void
+    {
+        $this->initial = $initial;
+        $this->touch();
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function markPersisted(
+        int $id,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null
+    ): void {
+        $this->id = $id;
+
+        if ($createdAt !== null) {
+            $this->createdAt = $createdAt;
+        }
+
+        if ($updatedAt !== null) {
+            $this->updatedAt = $updatedAt;
+        }
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/src/Domain/Workflow/WorkflowStateType.php
+++ b/src/Domain/Workflow/WorkflowStateType.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Workflow;
+
+enum WorkflowStateType: string
+{
+    case Draft = 'draft';
+    case Review = 'review';
+    case Published = 'published';
+    case Archived = 'archived';
+
+    public function allowsPublication(): bool
+    {
+        return $this === self::Published;
+    }
+
+    public function isReview(): bool
+    {
+        return $this === self::Review;
+    }
+
+    public function isDraft(): bool
+    {
+        return $this === self::Draft;
+    }
+
+    public function isArchived(): bool
+    {
+        return $this === self::Archived;
+    }
+}

--- a/src/Domain/Workflow/WorkflowTransition.php
+++ b/src/Domain/Workflow/WorkflowTransition.php
@@ -1,0 +1,182 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Domain\Workflow;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+final class WorkflowTransition
+{
+    private ?int $id;
+
+    private string $uid;
+
+    private Workflow $workflow;
+
+    private WorkflowState $from;
+
+    private WorkflowState $to;
+
+    private string $name;
+
+    /** @var array<string, bool> */
+    private array $roles = [];
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param string[] $roles
+     */
+    public function __construct(
+        Workflow $workflow,
+        WorkflowState $from,
+        WorkflowState $to,
+        string $name,
+        array $roles = [],
+        ?int $id = null,
+        ?string $uid = null,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null
+    ) {
+        if ($from->getWorkflow() !== $workflow || $to->getWorkflow() !== $workflow) {
+            throw new InvalidArgumentException('Workflow transition states must belong to the same workflow.');
+        }
+
+        $this->workflow = $workflow;
+        $this->from = $from;
+        $this->to = $to;
+        $this->name = $name;
+        $this->id = $id;
+        $this->uid = $uid ?? bin2hex(random_bytes(16));
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+        $this->updatedAt = $updatedAt ?? new DateTimeImmutable();
+
+        foreach ($roles as $role) {
+            if (!is_string($role) || $role === '') {
+                continue;
+            }
+
+            $this->roles[$role] = true;
+        }
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function getWorkflow(): Workflow
+    {
+        return $this->workflow;
+    }
+
+    public function getFrom(): WorkflowState
+    {
+        return $this->from;
+    }
+
+    public function getTo(): WorkflowState
+    {
+        return $this->to;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        if ($name === '') {
+            throw new InvalidArgumentException('Workflow transition name can not be empty.');
+        }
+
+        $this->name = $name;
+        $this->touch();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array
+    {
+        return array_keys($this->roles);
+    }
+
+    public function allowRole(string $role): void
+    {
+        if ($role === '') {
+            return;
+        }
+
+        if (isset($this->roles[$role])) {
+            return;
+        }
+
+        $this->roles[$role] = true;
+        $this->touch();
+    }
+
+    public function forbidRole(string $role): void
+    {
+        if (!isset($this->roles[$role])) {
+            return;
+        }
+
+        unset($this->roles[$role]);
+        $this->touch();
+    }
+
+    public function canExecute(string $role): bool
+    {
+        return $this->roles === [] || isset($this->roles[$role]);
+    }
+
+    public function markPersisted(
+        int $id,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null
+    ): void {
+        $this->id = $id;
+
+        if ($createdAt !== null) {
+            $this->createdAt = $createdAt;
+        }
+
+        if ($updatedAt !== null) {
+            $this->updatedAt = $updatedAt;
+        }
+    }
+
+    public function replaceRoles(array $roles): void
+    {
+        $this->roles = [];
+        foreach ($roles as $role) {
+            if (!is_string($role) || $role === '') {
+                continue;
+            }
+
+            $this->roles[$role] = true;
+        }
+        $this->touch();
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/src/Http/Dashboard/Controllers/WorkflowController.php
+++ b/src/Http/Dashboard/Controllers/WorkflowController.php
@@ -9,10 +9,42 @@ declare(strict_types=1);
 
 namespace Setka\Cms\Http\Dashboard\Controllers;
 
+use InvalidArgumentException;
+use RuntimeException;
+use Setka\Cms\Application\Elements\ElementVersionService;
+use Setka\Cms\Contracts\Elements\ElementRepositoryInterface;
+use Setka\Cms\Contracts\Workflow\WorkflowRepositoryInterface;
+use Setka\Cms\Contracts\Workflow\WorkflowStateRepositoryInterface;
+use Setka\Cms\Contracts\Workflow\WorkflowTransitionRepositoryInterface;
+use Setka\Cms\Domain\Elements\Element;
+use Setka\Cms\Domain\Workflow\Workflow;
+use Setka\Cms\Domain\Workflow\WorkflowState;
+use Setka\Cms\Domain\Workflow\WorkflowStateType;
+use Setka\Cms\Domain\Workflow\WorkflowTransition;
+use Setka\Cms\Domain\Workspaces\Workspace;
+use Yii;
+use yii\web\BadRequestHttpException;
 use yii\web\Controller;
+use yii\web\NotFoundHttpException;
+use yii\web\Response;
 
 final class WorkflowController extends Controller
 {
+    private const DEFAULT_ROLES = ['author', 'editor', 'publisher', 'admin'];
+
+    public function __construct(
+        $id,
+        $module,
+        private readonly WorkflowRepositoryInterface $workflowRepository,
+        private readonly WorkflowStateRepositoryInterface $stateRepository,
+        private readonly WorkflowTransitionRepositoryInterface $transitionRepository,
+        private readonly ElementRepositoryInterface $elementRepository,
+        private readonly ElementVersionService $versionService,
+        array $config = []
+    ) {
+        parent::__construct($id, $module, $config);
+    }
+
     public function actionIndex(): string
     {
         return $this->render('index');
@@ -26,5 +58,410 @@ final class WorkflowController extends Controller
     public function actionTransitions(): string
     {
         return $this->render('transitions');
+    }
+
+    public function actionStatesData(): Response
+    {
+        $workflow = $this->getWorkflow();
+        $states = $this->stateRepository->findByWorkflow($workflow);
+
+        return $this->asJson([
+            'items' => array_map([$this, 'serialiseState'], $states),
+        ]);
+    }
+
+    public function actionCreateState(): Response
+    {
+        $workflow = $this->getWorkflow();
+        $payload = Yii::$app->request->post();
+        $handle = (string) ($payload['handle'] ?? '');
+        $name = (string) ($payload['name'] ?? '');
+        $type = $this->resolveStateType($payload['type'] ?? null);
+        $color = (string) ($payload['color'] ?? '#3c8dbc');
+        $isInitial = isset($payload['is_initial']) ? (bool) $payload['is_initial'] : false;
+
+        $position = count($this->stateRepository->findByWorkflow($workflow)) + 1;
+        $state = new WorkflowState(
+            workflow: $workflow,
+            handle: $handle !== '' ? $handle : 'state-' . $position,
+            name: $name !== '' ? $name : 'Новый статус',
+            type: $type,
+            color: $color !== '' ? $color : '#3c8dbc',
+            initial: $isInitial,
+            position: $position,
+        );
+
+        $this->stateRepository->save($state);
+
+        return $this->asJson([
+            'item' => $this->serialiseState($state),
+        ]);
+    }
+
+    public function actionUpdateState(int $id): Response
+    {
+        $workflow = $this->getWorkflow();
+        $state = $this->stateRepository->findById($workflow, $id);
+        if ($state === null) {
+            throw new NotFoundHttpException('Статус не найден.');
+        }
+
+        $payload = Yii::$app->request->post();
+        if (isset($payload['name'])) {
+            $state->setName((string) $payload['name']);
+        }
+
+        if (isset($payload['handle'])) {
+            $state->setHandle((string) $payload['handle']);
+        }
+
+        if (isset($payload['type'])) {
+            $state->setType($this->resolveStateType($payload['type']));
+        }
+
+        if (isset($payload['color'])) {
+            $state->setColor((string) $payload['color']);
+        }
+
+        if (isset($payload['is_initial'])) {
+            $state->markInitial((bool) $payload['is_initial']);
+        }
+
+        $this->stateRepository->save($state);
+
+        return $this->asJson([
+            'item' => $this->serialiseState($state),
+        ]);
+    }
+
+    public function actionDeleteState(int $id): Response
+    {
+        $workflow = $this->getWorkflow();
+        $this->stateRepository->delete($workflow, $id);
+
+        return $this->asJson(['success' => true]);
+    }
+
+    public function actionReorderStates(): Response
+    {
+        $workflow = $this->getWorkflow();
+        $payload = Yii::$app->request->post();
+        $ids = $payload['ids'] ?? [];
+        if (!is_array($ids)) {
+            throw new BadRequestHttpException('Некорректный список идентификаторов.');
+        }
+
+        $orderedIds = array_map(static fn($value) => (int) $value, $ids);
+        $this->stateRepository->reorder($workflow, $orderedIds);
+
+        return $this->asJson(['success' => true]);
+    }
+
+    public function actionTransitionsData(): Response
+    {
+        $workflow = $this->getWorkflow();
+        $transitions = $this->transitionRepository->findByWorkflow($workflow);
+
+        return $this->asJson([
+            'items' => array_map([$this, 'serialiseTransition'], $transitions),
+            'roles' => self::DEFAULT_ROLES,
+        ]);
+    }
+
+    public function actionCreateTransition(): Response
+    {
+        $workflow = $this->getWorkflow();
+        $payload = Yii::$app->request->post();
+        $name = (string) ($payload['name'] ?? '');
+        $fromId = isset($payload['from_state_id']) ? (int) $payload['from_state_id'] : null;
+        $toId = isset($payload['to_state_id']) ? (int) $payload['to_state_id'] : null;
+        if ($fromId === null || $toId === null) {
+            throw new BadRequestHttpException('Не указаны исходный или целевой статус.');
+        }
+
+        $fromState = $this->stateRepository->findById($workflow, $fromId);
+        $toState = $this->stateRepository->findById($workflow, $toId);
+        if ($fromState === null || $toState === null) {
+            throw new NotFoundHttpException('Статус для перехода не найден.');
+        }
+
+        $roles = $this->normaliseRoles($payload['roles'] ?? []);
+        $transition = new WorkflowTransition(
+            workflow: $workflow,
+            from: $fromState,
+            to: $toState,
+            name: $name !== '' ? $name : sprintf('%s → %s', $fromState->getName(), $toState->getName()),
+            roles: $roles,
+        );
+
+        $this->transitionRepository->save($transition);
+
+        return $this->asJson([
+            'item' => $this->serialiseTransition($transition),
+        ]);
+    }
+
+    public function actionUpdateTransition(int $id): Response
+    {
+        $workflow = $this->getWorkflow();
+        $existing = $this->transitionRepository->findById($workflow, $id);
+        if ($existing === null) {
+            throw new NotFoundHttpException('Переход не найден.');
+        }
+
+        $payload = Yii::$app->request->post();
+        $fromId = isset($payload['from_state_id']) ? (int) $payload['from_state_id'] : $existing->getFrom()->getId();
+        $toId = isset($payload['to_state_id']) ? (int) $payload['to_state_id'] : $existing->getTo()->getId();
+        if ($fromId === null || $toId === null) {
+            throw new BadRequestHttpException('Не указаны исходный или целевой статус.');
+        }
+
+        $fromState = $this->stateRepository->findById($workflow, $fromId);
+        $toState = $this->stateRepository->findById($workflow, $toId);
+        if ($fromState === null || $toState === null) {
+            throw new NotFoundHttpException('Статус для перехода не найден.');
+        }
+
+        $roles = $this->normaliseRoles($payload['roles'] ?? $existing->getRoles());
+        $updated = new WorkflowTransition(
+            workflow: $workflow,
+            from: $fromState,
+            to: $toState,
+            name: isset($payload['name']) ? (string) $payload['name'] : $existing->getName(),
+            roles: $roles,
+            id: $existing->getId(),
+            uid: $existing->getUid(),
+            createdAt: $existing->getCreatedAt(),
+        );
+
+        $this->transitionRepository->save($updated);
+
+        return $this->asJson([
+            'item' => $this->serialiseTransition($updated),
+        ]);
+    }
+
+    public function actionDeleteTransition(int $id): Response
+    {
+        $workflow = $this->getWorkflow();
+        $this->transitionRepository->delete($workflow, $id);
+
+        return $this->asJson(['success' => true]);
+    }
+
+    public function actionApplyTransition(): Response
+    {
+        $payload = Yii::$app->request->post();
+        $transitionId = isset($payload['transition_id']) ? (int) $payload['transition_id'] : null;
+        $role = (string) ($payload['role'] ?? '');
+        $elementId = isset($payload['element_id']) ? (int) $payload['element_id'] : null;
+        $workspaceId = isset($payload['workspace_id']) ? (int) $payload['workspace_id'] : null;
+        $locale = isset($payload['locale']) ? (string) $payload['locale'] : '';
+        $version = isset($payload['version']) ? (int) $payload['version'] : null;
+        if ($transitionId === null) {
+            throw new BadRequestHttpException('Не указан переход.');
+        }
+
+        $workflow = $this->getWorkflow();
+        $transition = $this->transitionRepository->findById($workflow, $transitionId);
+        if ($transition === null) {
+            throw new NotFoundHttpException('Переход не найден.');
+        }
+
+        if ($role === '') {
+            throw new BadRequestHttpException('Не указана роль.');
+        }
+
+        $allowed = $transition->canExecute($role);
+        if (!$allowed) {
+            return $this->asJson([
+                'success' => false,
+                'message' => 'Роль не имеет прав на выполнение перехода.',
+            ]);
+        }
+
+        if ($elementId === null || $elementId <= 0) {
+            throw new BadRequestHttpException('Не указан элемент для изменения статуса.');
+        }
+
+        if ($workspaceId === null || $workspaceId <= 0) {
+            throw new BadRequestHttpException('Не указан рабочий простор.');
+        }
+
+        $locale = trim($locale);
+        if ($locale === '') {
+            throw new BadRequestHttpException('Не указан язык элемента.');
+        }
+
+        if ($version !== null && $version <= 0) {
+            $version = null;
+        }
+
+        $workspace = $this->createWorkspaceStub($workspaceId, $locale);
+        $element = $this->elementRepository->findById($workspace, $elementId, $locale);
+        if ($element === null) {
+            throw new NotFoundHttpException('Элемент не найден или недоступен.');
+        }
+
+        $fromState = $transition->getFrom();
+        $this->assertTransitionCompatible($element, $fromState);
+
+        $targetState = $transition->getTo();
+        if ($targetState->getId() === null) {
+            throw new BadRequestHttpException('Целевой статус недоступен для применения.');
+        }
+        $element->setWorkflowState($targetState);
+
+        try {
+            $this->applyStateEffects($element, $targetState, $locale, $version);
+        } catch (RuntimeException|InvalidArgumentException $exception) {
+            return $this->asJson([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ]);
+        }
+
+        return $this->asJson([
+            'success' => true,
+            'target_state' => $this->serialiseState($targetState),
+            'element' => $this->serialiseElement($element),
+            'message' => sprintf('Переход «%s» выполнен.', $transition->getName()),
+        ]);
+    }
+
+    private function getWorkflow(): Workflow
+    {
+        $workflow = $this->workflowRepository->findDefault();
+        if ($workflow !== null) {
+            return $workflow;
+        }
+
+        $workflow = new Workflow('default', 'Стандартный процесс');
+        $this->workflowRepository->save($workflow);
+
+        return $workflow;
+    }
+
+    private function resolveStateType(mixed $value): WorkflowStateType
+    {
+        if (is_string($value)) {
+            $type = WorkflowStateType::tryFrom($value);
+            if ($type !== null) {
+                return $type;
+            }
+        }
+
+        return WorkflowStateType::Draft;
+    }
+
+    /**
+     * @param string[] $roles
+     * @return string[]
+     */
+    private function normaliseRoles(array $roles): array
+    {
+        $filtered = [];
+        foreach ($roles as $role) {
+            if (!is_string($role) || $role === '') {
+                continue;
+            }
+
+            $filtered[] = $role;
+        }
+
+        return array_values(array_unique($filtered));
+    }
+
+    private function serialiseState(WorkflowState $state): array
+    {
+        return [
+            'id' => $state->getId(),
+            'handle' => $state->getHandle(),
+            'name' => $state->getName(),
+            'type' => $state->getType()->value,
+            'color' => $state->getColor(),
+            'is_initial' => $state->isInitial(),
+            'position' => $state->getPosition(),
+        ];
+    }
+
+    private function serialiseTransition(WorkflowTransition $transition): array
+    {
+        return [
+            'id' => $transition->getId(),
+            'name' => $transition->getName(),
+            'roles' => $transition->getRoles(),
+            'from' => $this->serialiseState($transition->getFrom()),
+            'to' => $this->serialiseState($transition->getTo()),
+        ];
+    }
+
+    private function serialiseElement(Element $element): array
+    {
+        return [
+            'id' => $element->getId(),
+            'status' => $element->getStatus()->value,
+            'workflow_state_id' => $element->getWorkflowStateId(),
+            'workflow_state_type' => $element->getWorkflowStateType()?->value,
+        ];
+    }
+
+    private function createWorkspaceStub(int $workspaceId, string $locale): Workspace
+    {
+        $handle = 'workspace-' . $workspaceId;
+        $name = 'Workspace #' . $workspaceId;
+
+        return new Workspace($handle, $name, [$locale], [], $workspaceId);
+    }
+
+    private function assertTransitionCompatible(Element $element, WorkflowState $fromState): void
+    {
+        $currentStateId = $element->getWorkflowStateId();
+        $fromId = $fromState->getId();
+
+        if ($fromId === null) {
+            return;
+        }
+
+        if ($currentStateId === null) {
+            if ($fromState->isInitial()) {
+                return;
+            }
+
+            throw new BadRequestHttpException('Элемент ещё не привязан к начальному статусу.');
+        }
+
+        if ($currentStateId !== $fromId) {
+            throw new BadRequestHttpException('Текущий статус элемента не соответствует выбранному переходу.');
+        }
+    }
+
+    private function applyStateEffects(Element $element, WorkflowState $targetState, string $locale, ?int $version): void
+    {
+        $workspace = $element->getCollection()->getWorkspace();
+        $type = $targetState->getType();
+
+        if ($type === WorkflowStateType::Published) {
+            $this->versionService->publish($element, $locale, $version);
+
+            return;
+        }
+
+        if ($type === WorkflowStateType::Archived) {
+            $this->versionService->archive($element, $locale);
+
+            return;
+        }
+
+        if ($type === WorkflowStateType::Draft) {
+            $current = $element->getCurrentVersion($locale);
+            if ($current === null || !$current->getStatus()->isDraft()) {
+                $this->versionService->createDraft($element, $locale);
+
+                return;
+            }
+        }
+
+        $this->elementRepository->save($workspace, $element, $locale);
     }
 }

--- a/src/Http/Dashboard/Module.php
+++ b/src/Http/Dashboard/Module.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /*
  * This file is part of Setka CMS.
  *
@@ -8,6 +8,13 @@
 namespace Setka\Cms\Http\Dashboard;
 
 use RuntimeException;
+use Setka\Cms\Application\Elements\ElementVersionService;
+use Setka\Cms\Contracts\Elements\ElementRepositoryInterface;
+use Setka\Cms\Contracts\Elements\ElementVersionRepositoryInterface;
+use Setka\Cms\Contracts\Fields\FieldValueRepositoryInterface;
+use Setka\Cms\Contracts\Workflow\WorkflowRepositoryInterface;
+use Setka\Cms\Contracts\Workflow\WorkflowStateRepositoryInterface;
+use Setka\Cms\Contracts\Workflow\WorkflowTransitionRepositoryInterface;
 use Setka\Cms\Domain\Dashboard\ActivityRepositoryInterface;
 use Setka\Cms\Domain\Dashboard\MetricsRepositoryInterface;
 use Setka\Cms\Domain\Dashboard\QuickActionRepositoryInterface;
@@ -17,6 +24,12 @@ use Setka\Cms\Infrastructure\Dashboard\InMemoryActivityRepository;
 use Setka\Cms\Infrastructure\Dashboard\InMemoryMetricsRepository;
 use Setka\Cms\Infrastructure\Dashboard\InMemoryQuickActionRepository;
 use Setka\Cms\Infrastructure\Dashboard\InMemoryWarningRepository;
+use Setka\Cms\Infrastructure\DBAL\Repositories\ElementRepository;
+use Setka\Cms\Infrastructure\DBAL\Repositories\ElementVersionRepository;
+use Setka\Cms\Infrastructure\DBAL\Repositories\FieldValueRepository;
+use Setka\Cms\Infrastructure\DBAL\Repositories\WorkflowRepository;
+use Setka\Cms\Infrastructure\DBAL\Repositories\WorkflowStateRepository;
+use Setka\Cms\Infrastructure\DBAL\Repositories\WorkflowTransitionRepository;
 use Yii;
 use yii\base\Module as BaseModule;
 
@@ -79,6 +92,13 @@ class Module extends BaseModule
         $container->set(ActivityRepositoryInterface::class, InMemoryActivityRepository::class);
         $container->set(WarningRepositoryInterface::class, InMemoryWarningRepository::class);
         $container->set(QuickActionRepositoryInterface::class, InMemoryQuickActionRepository::class);
+        $container->set(FieldValueRepositoryInterface::class, FieldValueRepository::class);
+        $container->set(ElementVersionRepositoryInterface::class, ElementVersionRepository::class);
+        $container->set(ElementRepositoryInterface::class, ElementRepository::class);
+        $container->set(ElementVersionService::class, ElementVersionService::class);
+        $container->set(WorkflowRepositoryInterface::class, WorkflowRepository::class);
+        $container->set(WorkflowStateRepositoryInterface::class, WorkflowStateRepository::class);
+        $container->set(WorkflowTransitionRepositoryInterface::class, WorkflowTransitionRepository::class);
     }
 }
 

--- a/src/Http/Dashboard/Views/workflow/states.php
+++ b/src/Http/Dashboard/Views/workflow/states.php
@@ -2,42 +2,54 @@
 
 declare(strict_types=1);
 
+use yii\helpers\Html;
+use yii\helpers\Url;
+
 /* @var $this yii\web\View */
 
 $this->title = 'Статусы рабочего процесса';
 $this->params['breadcrumbs'][] = ['label' => 'Рабочие процессы', 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;
+
+$statesEndpoint = Url::to(['states-data']);
+$stateCreateUrl = Url::to(['create-state']);
+$stateUpdateUrl = Url::to(['update-state']);
+$stateDeleteUrl = Url::to(['delete-state']);
+$stateReorderUrl = Url::to(['reorder-states']);
+
+$typeOptions = [
+    'draft' => 'Черновик',
+    'review' => 'Ревью',
+    'published' => 'Публикация',
+    'archived' => 'Архив',
+];
 ?>
 
-<div class="box box-primary" data-role="workflow-states">
+<div
+    class="box box-primary"
+    data-role="workflow-states"
+    data-states-url="<?= Html::encode($statesEndpoint) ?>"
+    data-create-url="<?= Html::encode($stateCreateUrl) ?>"
+    data-update-url="<?= Html::encode($stateUpdateUrl) ?>"
+    data-delete-url="<?= Html::encode($stateDeleteUrl) ?>"
+    data-reorder-url="<?= Html::encode($stateReorderUrl) ?>"
+>
     <div class="box-header with-border">
         <h3 class="box-title">Статусы</h3>
         <div class="box-tools">
-            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#state-modal">
+            <button type="button" class="btn btn-success btn-sm" data-action="open-state-modal">
                 <i class="fa fa-plus"></i> Добавить статус
             </button>
         </div>
     </div>
     <div class="box-body">
         <p class="text-muted small">Перетащите статусы, чтобы изменить порядок переходов.</p>
-        <div class="list-group" data-role="states-list">
-            <a href="#" class="list-group-item">
-                <span class="state-handle"><i class="fa fa-bars"></i></span>
-                Черновик
-            </a>
-            <a href="#" class="list-group-item">
-                <span class="state-handle"><i class="fa fa-bars"></i></span>
-                На ревью
-            </a>
-            <a href="#" class="list-group-item">
-                <span class="state-handle"><i class="fa fa-bars"></i></span>
-                Опубликовано
-            </a>
-        </div>
+        <div class="list-group" data-role="states-list"></div>
+        <p class="text-muted text-center hidden" data-role="states-empty">Статусы ещё не настроены.</p>
     </div>
 </div>
 
-<div class="modal fade" id="state-modal" tabindex="-1" role="dialog" aria-labelledby="state-modal-label">
+<div class="modal fade" id="state-modal" tabindex="-1" role="dialog" aria-labelledby="state-modal-label" data-role="state-modal">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -46,13 +58,32 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
             <div class="modal-body">
                 <form data-role="state-form">
+                    <input type="hidden" name="id" data-role="state-id">
                     <div class="form-group">
                         <label for="state-name">Название</label>
-                        <input type="text" id="state-name" class="form-control" placeholder="На проверке">
+                        <input type="text" id="state-name" name="name" class="form-control" placeholder="На проверке" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="state-handle">Системное имя</label>
+                        <input type="text" id="state-handle" name="handle" class="form-control" placeholder="review" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="state-type">Тип</label>
+                        <select id="state-type" name="type" class="form-control select2" data-placeholder="Выберите тип">
+                            <?php foreach ($typeOptions as $value => $label): ?>
+                                <option value="<?= Html::encode($value) ?>"><?= Html::encode($label) ?></option>
+                            <?php endforeach; ?>
+                        </select>
                     </div>
                     <div class="form-group">
                         <label for="state-color">Цвет</label>
-                        <input type="color" id="state-color" class="form-control" value="#3c8dbc">
+                        <input type="color" id="state-color" name="color" class="form-control" value="#3c8dbc">
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="is_initial" value="1" data-role="state-initial">
+                            Использовать как начальный статус
+                        </label>
                     </div>
                 </form>
             </div>

--- a/src/Http/Dashboard/Views/workflow/transitions.php
+++ b/src/Http/Dashboard/Views/workflow/transitions.php
@@ -2,18 +2,34 @@
 
 declare(strict_types=1);
 
+use yii\helpers\Html;
+use yii\helpers\Url;
+
 /* @var $this yii\web\View */
 
 $this->title = 'Переходы рабочего процесса';
 $this->params['breadcrumbs'][] = ['label' => 'Рабочие процессы', 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;
+
+$transitionsEndpoint = Url::to(['transitions-data']);
+$transitionCreateUrl = Url::to(['create-transition']);
+$transitionUpdateUrl = Url::to(['update-transition']);
+$transitionDeleteUrl = Url::to(['delete-transition']);
+
 ?>
 
-<div class="box box-primary" data-role="workflow-transitions">
+<div
+    class="box box-primary"
+    data-role="workflow-transitions"
+    data-transitions-url="<?= Html::encode($transitionsEndpoint) ?>"
+    data-create-url="<?= Html::encode($transitionCreateUrl) ?>"
+    data-update-url="<?= Html::encode($transitionUpdateUrl) ?>"
+    data-delete-url="<?= Html::encode($transitionDeleteUrl) ?>"
+>
     <div class="box-header with-border">
         <h3 class="box-title">Переходы</h3>
         <div class="box-tools">
-            <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#transition-modal">
+            <button type="button" class="btn btn-success btn-sm" data-action="open-transition-modal">
                 <i class="fa fa-plus"></i> Добавить переход
             </button>
         </div>
@@ -25,12 +41,12 @@ $this->params['breadcrumbs'][] = $this->title;
                 <tr>
                     <th>Из статуса</th>
                     <th class="hidden-xs">В статус</th>
-                    <th class="hidden-xs">Роль</th>
-                    <th style="width: 120px;" class="text-right">Действия</th>
+                    <th class="hidden-xs">Роли</th>
+                    <th style="width: 140px;" class="text-right">Действия</th>
                 </tr>
                 </thead>
-                <tbody>
-                <tr class="empty">
+                <tbody data-role="transitions-body">
+                <tr class="hidden" data-role="transition-empty">
                     <td colspan="4" class="text-muted text-center">Переходы не настроены.</td>
                 </tr>
                 </tbody>
@@ -39,7 +55,7 @@ $this->params['breadcrumbs'][] = $this->title;
     </div>
 </div>
 
-<div class="modal fade" id="transition-modal" tabindex="-1" role="dialog" aria-labelledby="transition-modal-label">
+<div class="modal fade" id="transition-modal" tabindex="-1" role="dialog" aria-labelledby="transition-modal-label" data-role="transition-modal">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -48,26 +64,23 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
             <div class="modal-body">
                 <form data-role="transition-form">
+                    <input type="hidden" name="id" data-role="transition-id">
+                    <div class="form-group">
+                        <label for="transition-name">Название</label>
+                        <input type="text" id="transition-name" name="name" class="form-control" placeholder="Например, 'На ревью'">
+                    </div>
                     <div class="form-group">
                         <label for="transition-from">Из статуса</label>
-                        <select id="transition-from" class="form-control select2">
-                            <option value="draft">Черновик</option>
-                            <option value="review">На ревью</option>
-                        </select>
+                        <select id="transition-from" name="from_state_id" class="form-control select2" data-role="transition-from"></select>
                     </div>
                     <div class="form-group">
                         <label for="transition-to">В статус</label>
-                        <select id="transition-to" class="form-control select2">
-                            <option value="review">На ревью</option>
-                            <option value="published">Опубликовано</option>
-                        </select>
+                        <select id="transition-to" name="to_state_id" class="form-control select2" data-role="transition-to"></select>
                     </div>
                     <div class="form-group">
-                        <label for="transition-role">Роль</label>
-                        <select id="transition-role" class="form-control select2">
-                            <option value="editor">Редактор</option>
-                            <option value="admin">Администратор</option>
-                        </select>
+                        <label for="transition-roles">Доступные роли</label>
+                        <select id="transition-roles" name="roles[]" class="form-control select2" multiple data-role="transition-roles"></select>
+                        <p class="help-block">Выберите роли, которым разрешено выполнять переход. Если роли не выбраны, переход доступен всем.</p>
                     </div>
                 </form>
             </div>

--- a/src/Infrastructure/DBAL/Repositories/WorkflowRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/WorkflowRepository.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\DBAL\Repositories;
+
+use DateTimeImmutable;
+use Setka\Cms\Contracts\Workflow\WorkflowRepositoryInterface;
+use Setka\Cms\Domain\Workflow\Workflow;
+use yii\db\Connection;
+use yii\db\Query;
+
+final class WorkflowRepository implements WorkflowRepositoryInterface
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function findById(int $id): ?Workflow
+    {
+        $row = (new Query())
+            ->from('{{%workflow}}')
+            ->where(['id' => $id])
+            ->limit(1)
+            ->one($this->db);
+
+        if ($row === false || $row === null) {
+            return null;
+        }
+
+        return $this->hydrate($row);
+    }
+
+    public function findDefault(): ?Workflow
+    {
+        $row = (new Query())
+            ->from('{{%workflow}}')
+            ->orderBy(['id' => SORT_ASC])
+            ->limit(1)
+            ->one($this->db);
+
+        if ($row === false || $row === null) {
+            return null;
+        }
+
+        return $this->hydrate($row);
+    }
+
+    public function save(Workflow $workflow): void
+    {
+        $timestamp = time();
+        $data = [
+            'uid' => $workflow->getUid(),
+            'handle' => $workflow->getHandle(),
+            'name' => $workflow->getName(),
+            'description' => $workflow->getDescription(),
+            'updated_at' => $timestamp,
+        ];
+
+        $id = $workflow->getId();
+        if ($id === null) {
+            $data['created_at'] = $timestamp;
+            $this->db->createCommand()
+                ->insert('{{%workflow}}', $data)
+                ->execute();
+
+            $generatedId = (int) $this->db->getLastInsertID();
+            $date = new DateTimeImmutable('@' . $timestamp);
+            $workflow->markPersisted($generatedId, $workflow->getUid(), $date, $date);
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->update('{{%workflow}}', $data, ['id' => $id])
+            ->execute();
+
+        $workflow->markPersisted(
+            $id,
+            $workflow->getUid(),
+            $workflow->getCreatedAt(),
+            new DateTimeImmutable('@' . $timestamp)
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): Workflow
+    {
+        $workflow = new Workflow(
+            handle: (string) ($row['handle'] ?? 'default'),
+            name: (string) ($row['name'] ?? 'Workflow'),
+            description: (string) ($row['description'] ?? ''),
+            id: isset($row['id']) ? (int) $row['id'] : null,
+            uid: isset($row['uid']) ? (string) $row['uid'] : null,
+            createdAt: isset($row['created_at']) && $row['created_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row['created_at'])
+                : null,
+            updatedAt: isset($row['updated_at']) && $row['updated_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row['updated_at'])
+                : null,
+        );
+
+        return $workflow;
+    }
+}

--- a/src/Infrastructure/DBAL/Repositories/WorkflowStateRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/WorkflowStateRepository.php
@@ -1,0 +1,174 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\DBAL\Repositories;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Setka\Cms\Contracts\Workflow\WorkflowStateRepositoryInterface;
+use Setka\Cms\Domain\Workflow\Workflow;
+use Setka\Cms\Domain\Workflow\WorkflowState;
+use Setka\Cms\Domain\Workflow\WorkflowStateType;
+use yii\db\Connection;
+use yii\db\Query;
+
+final class WorkflowStateRepository implements WorkflowStateRepositoryInterface
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function findByWorkflow(Workflow $workflow): array
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return [];
+        }
+
+        $rows = (new Query())
+            ->from('{{%workflow_state}}')
+            ->where(['workflow_id' => $workflowId])
+            ->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC])
+            ->all($this->db);
+
+        if ($rows === []) {
+            return [];
+        }
+
+        $states = [];
+        foreach ($rows as $row) {
+            $states[] = $this->hydrate($workflow, $row);
+        }
+
+        return $states;
+    }
+
+    public function findById(Workflow $workflow, int $id): ?WorkflowState
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return null;
+        }
+
+        $row = (new Query())
+            ->from('{{%workflow_state}}')
+            ->where(['id' => $id, 'workflow_id' => $workflowId])
+            ->limit(1)
+            ->one($this->db);
+
+        if ($row === false || $row === null) {
+            return null;
+        }
+
+        return $this->hydrate($workflow, $row);
+    }
+
+    public function save(WorkflowState $state): void
+    {
+        $workflow = $state->getWorkflow();
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            throw new InvalidArgumentException('Workflow must be persisted before saving states.');
+        }
+
+        $timestamp = time();
+        $data = [
+            'uid' => $state->getUid(),
+            'workflow_id' => $workflowId,
+            'handle' => $state->getHandle(),
+            'name' => $state->getName(),
+            'type' => $state->getType()->value,
+            'color' => $state->getColor(),
+            'is_initial' => $state->isInitial() ? 1 : 0,
+            'position' => $state->getPosition(),
+            'updated_at' => $timestamp,
+        ];
+
+        $id = $state->getId();
+        if ($id === null) {
+            $data['created_at'] = $timestamp;
+            $this->db->createCommand()
+                ->insert('{{%workflow_state}}', $data)
+                ->execute();
+
+            $generatedId = (int) $this->db->getLastInsertID();
+            $date = new DateTimeImmutable('@' . $timestamp);
+            $state->markPersisted($generatedId, $date, $date);
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->update('{{%workflow_state}}', $data, ['id' => $id, 'workflow_id' => $workflowId])
+            ->execute();
+
+        $state->markPersisted(
+            $id,
+            $state->getCreatedAt(),
+            new DateTimeImmutable('@' . $timestamp)
+        );
+    }
+
+    public function delete(Workflow $workflow, int $id): void
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return;
+        }
+
+        $this->db->createCommand()
+            ->delete('{{%workflow_state}}', ['id' => $id, 'workflow_id' => $workflowId])
+            ->execute();
+    }
+
+    public function reorder(Workflow $workflow, array $orderedIds): void
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return;
+        }
+
+        $position = 1;
+        foreach ($orderedIds as $id) {
+            $this->db->createCommand()
+                ->update('{{%workflow_state}}', ['position' => $position], ['id' => $id, 'workflow_id' => $workflowId])
+                ->execute();
+            $position++;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(Workflow $workflow, array $row): WorkflowState
+    {
+        $typeValue = isset($row['type']) ? (string) $row['type'] : WorkflowStateType::Draft->value;
+        $type = WorkflowStateType::tryFrom($typeValue) ?? WorkflowStateType::Draft;
+
+        $state = new WorkflowState(
+            workflow: $workflow,
+            handle: (string) ($row['handle'] ?? 'state'),
+            name: (string) ($row['name'] ?? 'State'),
+            type: $type,
+            color: (string) ($row['color'] ?? '#3c8dbc'),
+            initial: isset($row['is_initial']) ? ((int) $row['is_initial']) === 1 : false,
+            position: isset($row['position']) ? (int) $row['position'] : 0,
+            id: isset($row['id']) ? (int) $row['id'] : null,
+            uid: isset($row['uid']) ? (string) $row['uid'] : null,
+            createdAt: isset($row['created_at']) && $row['created_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row['created_at'])
+                : null,
+            updatedAt: isset($row['updated_at']) && $row['updated_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row['updated_at'])
+                : null,
+        );
+
+        return $state;
+    }
+}

--- a/src/Infrastructure/DBAL/Repositories/WorkflowTransitionRepository.php
+++ b/src/Infrastructure/DBAL/Repositories/WorkflowTransitionRepository.php
@@ -1,0 +1,312 @@
+<?php
+/*
+ * This file is part of Setka CMS.
+ *
+ * @package   Setka CMS
+ */
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Infrastructure\DBAL\Repositories;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Setka\Cms\Contracts\Workflow\WorkflowTransitionRepositoryInterface;
+use Setka\Cms\Domain\Workflow\Workflow;
+use Setka\Cms\Domain\Workflow\WorkflowState;
+use Setka\Cms\Domain\Workflow\WorkflowStateType;
+use Setka\Cms\Domain\Workflow\WorkflowTransition;
+use yii\db\Connection;
+use yii\db\Query;
+
+final class WorkflowTransitionRepository implements WorkflowTransitionRepositoryInterface
+{
+    public function __construct(private readonly Connection $db)
+    {
+    }
+
+    public function findByWorkflow(Workflow $workflow): array
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return [];
+        }
+
+        $rows = $this->createBaseQuery($workflowId)
+            ->orderBy(['t.id' => SORT_ASC])
+            ->all($this->db);
+
+        if ($rows === []) {
+            return [];
+        }
+
+        $transitions = [];
+        foreach ($rows as $row) {
+            $transitions[] = $this->hydrate($workflow, $row);
+        }
+
+        if ($transitions === []) {
+            return [];
+        }
+
+        $this->loadRoles($transitions);
+
+        return $transitions;
+    }
+
+    public function findById(Workflow $workflow, int $id): ?WorkflowTransition
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return null;
+        }
+
+        $row = $this->createBaseQuery($workflowId)
+            ->andWhere(['t.id' => $id])
+            ->limit(1)
+            ->one($this->db);
+
+        if ($row === false || $row === null) {
+            return null;
+        }
+
+        $transition = $this->hydrate($workflow, $row);
+        $this->loadRoles([$transition]);
+
+        return $transition;
+    }
+
+    public function save(WorkflowTransition $transition): void
+    {
+        $workflow = $transition->getWorkflow();
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            throw new InvalidArgumentException('Workflow must be persisted before saving transitions.');
+        }
+
+        $fromState = $transition->getFrom();
+        $toState = $transition->getTo();
+        $fromId = $fromState->getId();
+        $toId = $toState->getId();
+        if ($fromId === null || $toId === null) {
+            throw new InvalidArgumentException('Workflow transition states must be persisted.');
+        }
+
+        $timestamp = time();
+        $data = [
+            'uid' => $transition->getUid(),
+            'workflow_id' => $workflowId,
+            'name' => $transition->getName(),
+            'from_state_id' => $fromId,
+            'to_state_id' => $toId,
+            'updated_at' => $timestamp,
+        ];
+
+        $id = $transition->getId();
+        if ($id === null) {
+            $data['created_at'] = $timestamp;
+            $this->db->createCommand()
+                ->insert('{{%workflow_transition}}', $data)
+                ->execute();
+
+            $generatedId = (int) $this->db->getLastInsertID();
+            $date = new DateTimeImmutable('@' . $timestamp);
+            $transition->markPersisted($generatedId, $date, $date);
+            $this->persistRoles($generatedId, $transition->getRoles());
+
+            return;
+        }
+
+        $this->db->createCommand()
+            ->update('{{%workflow_transition}}', $data, ['id' => $id, 'workflow_id' => $workflowId])
+            ->execute();
+
+        $transition->markPersisted(
+            $id,
+            $transition->getCreatedAt(),
+            new DateTimeImmutable('@' . $timestamp)
+        );
+        $this->persistRoles($id, $transition->getRoles());
+    }
+
+    public function delete(Workflow $workflow, int $id): void
+    {
+        $workflowId = $workflow->getId();
+        if ($workflowId === null) {
+            return;
+        }
+
+        $this->db->createCommand()
+            ->delete('{{%workflow_transition_role}}', ['transition_id' => $id])
+            ->execute();
+
+        $this->db->createCommand()
+            ->delete('{{%workflow_transition}}', ['id' => $id, 'workflow_id' => $workflowId])
+            ->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(Workflow $workflow, array $row): WorkflowTransition
+    {
+        $from = $this->hydrateState($workflow, $row, 'from');
+        $to = $this->hydrateState($workflow, $row, 'to');
+
+        $transition = new WorkflowTransition(
+            workflow: $workflow,
+            from: $from,
+            to: $to,
+            name: (string) ($row['name'] ?? 'Transition'),
+            roles: [],
+            id: isset($row['id']) ? (int) $row['id'] : null,
+            uid: isset($row['uid']) ? (string) $row['uid'] : null,
+            createdAt: isset($row['created_at']) && $row['created_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row['created_at'])
+                : null,
+            updatedAt: isset($row['updated_at']) && $row['updated_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row['updated_at'])
+                : null,
+        );
+
+        return $transition;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateState(Workflow $workflow, array $row, string $prefix): WorkflowState
+    {
+        $typeKey = $prefix . '_type';
+        $typeValue = isset($row[$typeKey]) ? (string) $row[$typeKey] : WorkflowStateType::Draft->value;
+        $type = WorkflowStateType::tryFrom($typeValue) ?? WorkflowStateType::Draft;
+
+        return new WorkflowState(
+            workflow: $workflow,
+            handle: (string) ($row[$prefix . '_handle'] ?? 'state'),
+            name: (string) ($row[$prefix . '_name'] ?? 'State'),
+            type: $type,
+            color: (string) ($row[$prefix . '_color'] ?? '#3c8dbc'),
+            initial: isset($row[$prefix . '_is_initial']) ? ((int) $row[$prefix . '_is_initial']) === 1 : false,
+            position: isset($row[$prefix . '_position']) ? (int) $row[$prefix . '_position'] : 0,
+            id: isset($row[$prefix . '_id']) ? (int) $row[$prefix . '_id'] : null,
+            uid: isset($row[$prefix . '_uid']) ? (string) $row[$prefix . '_uid'] : null,
+            createdAt: isset($row[$prefix . '_created_at']) && $row[$prefix . '_created_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row[$prefix . '_created_at'])
+                : null,
+            updatedAt: isset($row[$prefix . '_updated_at']) && $row[$prefix . '_updated_at'] !== null
+                ? new DateTimeImmutable('@' . (int) $row[$prefix . '_updated_at'])
+                : null,
+        );
+    }
+
+    /**
+     * @param WorkflowTransition[] $transitions
+     */
+    private function loadRoles(array $transitions): void
+    {
+        $ids = [];
+        foreach ($transitions as $transition) {
+            $id = $transition->getId();
+            if ($id !== null) {
+                $ids[] = $id;
+            }
+        }
+
+        if ($ids === []) {
+            return;
+        }
+
+        $rows = (new Query())
+            ->from('{{%workflow_transition_role}}')
+            ->where(['transition_id' => $ids])
+            ->all($this->db);
+
+        if ($rows === []) {
+            return;
+        }
+
+        $map = [];
+        foreach ($rows as $row) {
+            $transitionId = isset($row['transition_id']) ? (int) $row['transition_id'] : null;
+            $role = isset($row['role']) ? (string) $row['role'] : '';
+            if ($transitionId === null || $role === '') {
+                continue;
+            }
+
+            $map[$transitionId][] = $role;
+        }
+
+        foreach ($transitions as $transition) {
+            $id = $transition->getId();
+            if ($id === null) {
+                continue;
+            }
+
+            $transition->replaceRoles($map[$id] ?? []);
+        }
+    }
+
+    private function persistRoles(int $transitionId, array $roles): void
+    {
+        $this->db->createCommand()
+            ->delete('{{%workflow_transition_role}}', ['transition_id' => $transitionId])
+            ->execute();
+
+        if ($roles === []) {
+            return;
+        }
+
+        foreach ($roles as $role) {
+            if ($role === '') {
+                continue;
+            }
+
+            $this->db->createCommand()
+                ->insert('{{%workflow_transition_role}}', [
+                    'transition_id' => $transitionId,
+                    'role' => $role,
+                ])
+                ->execute();
+        }
+    }
+
+    private function createBaseQuery(int $workflowId): Query
+    {
+        return (new Query())
+            ->select([
+                't.id',
+                't.uid',
+                't.workflow_id',
+                't.name',
+                't.from_state_id',
+                't.to_state_id',
+                't.created_at',
+                't.updated_at',
+                'from_id' => 'fs.id',
+                'from_uid' => 'fs.uid',
+                'from_handle' => 'fs.handle',
+                'from_name' => 'fs.name',
+                'from_type' => 'fs.type',
+                'from_color' => 'fs.color',
+                'from_is_initial' => 'fs.is_initial',
+                'from_position' => 'fs.position',
+                'from_created_at' => 'fs.created_at',
+                'from_updated_at' => 'fs.updated_at',
+                'to_id' => 'ts.id',
+                'to_uid' => 'ts.uid',
+                'to_handle' => 'ts.handle',
+                'to_name' => 'ts.name',
+                'to_type' => 'ts.type',
+                'to_color' => 'ts.color',
+                'to_is_initial' => 'ts.is_initial',
+                'to_position' => 'ts.position',
+                'to_created_at' => 'ts.created_at',
+                'to_updated_at' => 'ts.updated_at',
+            ])
+            ->from(['t' => '{{%workflow_transition}}'])
+            ->innerJoin(['fs' => '{{%workflow_state}}'], 'fs.id = t.from_state_id')
+            ->innerJoin(['ts' => '{{%workflow_state}}'], 'ts.id = t.to_state_id')
+            ->where(['t.workflow_id' => $workflowId]);
+    }
+}

--- a/tests/Unit/Domain/Elements/ElementWorkflowTest.php
+++ b/tests/Unit/Domain/Elements/ElementWorkflowTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Elements;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Setka\Cms\Contracts\Elements\ElementStatus;
+use Setka\Cms\Domain\Elements\Collection;
+use Setka\Cms\Domain\Elements\CollectionStructure;
+use Setka\Cms\Domain\Elements\Element;
+use Setka\Cms\Domain\Workflow\WorkflowStateType;
+use Setka\Cms\Domain\Workspaces\Workspace;
+
+final class ElementWorkflowTest extends TestCase
+{
+    public function testPublishAllowedInPublishedState(): void
+    {
+        $element = $this->createElement();
+        $element->hydrateWorkflowState(10, WorkflowStateType::Published);
+        $element->createDraft();
+
+        $element->publish();
+
+        self::assertSame(ElementStatus::Published, $element->getStatus());
+        self::assertTrue($element->canPublish());
+    }
+
+    public function testPublishThrowsWhenWorkflowStateForbids(): void
+    {
+        $element = $this->createElement();
+        $element->hydrateWorkflowState(20, WorkflowStateType::Review);
+        $element->createDraft();
+
+        $this->expectException(RuntimeException::class);
+
+        $element->publish();
+    }
+
+    private function createElement(): Element
+    {
+        $workspace = new Workspace('default', 'Default workspace', ['ru-RU']);
+        $collection = new Collection(
+            workspace: $workspace,
+            handle: 'articles',
+            name: 'Статьи',
+            structure: CollectionStructure::FLAT
+        );
+
+        return new Element($collection, 'ru-RU');
+    }
+}

--- a/tests/Unit/Domain/Workflow/WorkflowTransitionTest.php
+++ b/tests/Unit/Domain/Workflow/WorkflowTransitionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setka\Cms\Tests\Unit\Domain\Workflow;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Setka\Cms\Domain\Workflow\Workflow;
+use Setka\Cms\Domain\Workflow\WorkflowState;
+use Setka\Cms\Domain\Workflow\WorkflowStateType;
+use Setka\Cms\Domain\Workflow\WorkflowTransition;
+
+final class WorkflowTransitionTest extends TestCase
+{
+    public function testTransitionHonoursRoles(): void
+    {
+        $workflow = new Workflow('default', 'Default workflow');
+        $from = new WorkflowState($workflow, 'draft', 'Черновик', WorkflowStateType::Draft, position: 1, initial: true);
+        $to = new WorkflowState($workflow, 'review', 'Ревью', WorkflowStateType::Review, position: 2);
+
+        $transition = new WorkflowTransition($workflow, $from, $to, 'На ревью', ['author', 'editor']);
+
+        self::assertTrue($transition->canExecute('author'));
+        self::assertTrue($transition->canExecute('editor'));
+        self::assertFalse($transition->canExecute('publisher'));
+
+        $transition->allowRole('publisher');
+        self::assertTrue($transition->canExecute('publisher'));
+
+        $transition->forbidRole('author');
+        self::assertFalse($transition->canExecute('author'));
+
+        $transition->replaceRoles(['owner']);
+        self::assertTrue($transition->canExecute('owner'));
+        self::assertFalse($transition->canExecute('editor'));
+    }
+
+    public function testTransitionRequiresSameWorkflow(): void
+    {
+        $workflow = new Workflow('default', 'Default');
+        $anotherWorkflow = new Workflow('secondary', 'Secondary');
+
+        $from = new WorkflowState($workflow, 'draft', 'Черновик', WorkflowStateType::Draft);
+        $to = new WorkflowState($anotherWorkflow, 'review', 'Ревью', WorkflowStateType::Review);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        new WorkflowTransition($workflow, $from, $to, 'Invalid');
+    }
+}


### PR DESCRIPTION
## Summary
- добавлены доменные сущности и репозитории workflow с миграцией, связывающей статусы с элементами
- расширен WorkflowController для полноценного CRUD и применения переходов с проверками и обновлением версии элемента
- настроен DI-доступ к workflow/element репозиториям и добавлены юнит-тесты для переходов и ограничений публикации

## Testing
- не запускалось (composer install завершается ошибкой 403 при скачивании пакетов)


------
https://chatgpt.com/codex/tasks/task_e_68cdf325c66c832db2640eed7ed8e27f