### PR TITLE
Исправить русские строки контроллеров коллекций

### DIFF
--- a/src/Http/Dashboard/Controllers/CollectionsController.php
+++ b/src/Http/Dashboard/Controllers/CollectionsController.php
@@ -35,9 +35,9 @@ final class CollectionsController extends Controller
     ];
 
     private const STATUS_LABELS = [
-        'published' => 'РћРїСѓР±Р»РёРєРѕРІР°РЅРѕ',
-        'draft' => 'Р§РµСЂРЅРѕРІРёРє',
-        'archived' => 'РђСЂС…РёРІ',
+        'published' => 'Опубликовано',
+        'draft' => 'Черновик',
+        'archived' => 'Архив',
     ];
 
     private const STATUS_BADGES = [
@@ -47,10 +47,10 @@ final class CollectionsController extends Controller
     ];
 
     private const STRUCTURE_LABELS = [
-        'flat' => 'РџР»РѕСЃРєР°СЏ',
-        'tree' => 'Р”СЂРµРІРѕРІРёРґРЅР°СЏ',
-        'calendar' => 'РљР°Р»РµРЅРґР°СЂСЊ',
-        'sequence' => 'РџРѕСЃР»РµРґРѕРІР°С‚РµР»СЊРЅРѕСЃС‚СЊ',
+        'flat' => 'Плоская',
+        'tree' => 'Древовидная',
+        'calendar' => 'Календарь',
+        'sequence' => 'Последовательность',
     ];
 
     private InMemoryCollectionEntriesRepository $collectionEntriesRepository;
@@ -91,7 +91,7 @@ final class CollectionsController extends Controller
 
         $collection = $this->findCollectionByHandle($handle);
         if ($collection === null) {
-            throw new NotFoundHttpException('РљРѕР»Р»РµРєС†РёСЏ РЅРµ РЅР°Р№РґРµРЅР°.');
+            throw new NotFoundHttpException('Коллекция не найдена.');
         }
 
         $this->assertCanViewEntries($collection);
@@ -129,7 +129,7 @@ final class CollectionsController extends Controller
     {
         $collection = $this->findCollectionByHandle($handle);
         if ($collection === null) {
-            throw new NotFoundHttpException('РљРѕР»Р»РµРєС†РёСЏ РЅРµ РЅР°Р№РґРµРЅР°.');
+            throw new NotFoundHttpException('Коллекция не найдена.');
         }
 
         $this->assertCanViewEntries($collection);

--- a/src/Http/Dashboard/Controllers/EntriesController.php
+++ b/src/Http/Dashboard/Controllers/EntriesController.php
@@ -38,7 +38,7 @@ final class EntriesController extends Controller
     {
         $collection = $this->collectionsRepository->findByHandle($handle);
         if ($collection === null) {
-            throw new NotFoundHttpException('пїЅ?пїЅ?пїЅ>пїЅ>пїЅпїЅпїЅЕђпїЅ? пїЅ?пїЅпїЅ пїЅ?пїЅпїЅпїЅпїЅпїЅ?пїЅпїЅ?пїЅпїЅ.');
+            throw new NotFoundHttpException('Коллекция не найдена.');
         }
 
         $this->assertCanViewEntries($collection);
@@ -52,7 +52,7 @@ final class EntriesController extends Controller
         } else {
             $entry = $this->findEntry($collection, $normalizedId);
             if ($entry === null) {
-                throw new NotFoundHttpException('Р—Р°РїРёСЃСЊ РєРѕР»Р»РµРєС†РёРё РЅРµ РЅР°Р№РґРµРЅР°.');
+                throw new NotFoundHttpException('Запись коллекции не найдена.');
             }
         }
 


### PR DESCRIPTION
## Summary
- заменить подписи статусов и структур коллекций на корректные русские формулировки
- привести сообщения об ошибках NotFoundHttpException в контроллерах коллекций и записей к понятным строкам

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdfc4fe70c832dbf543374351b034c