### PR TITLE
Set default dashboard route to index action

### DIFF
--- a/src/Http/Dashboard/Module.php
+++ b/src/Http/Dashboard/Module.php
@@ -36,6 +36,7 @@ use yii\base\Module as BaseModule;
 class Module extends BaseModule
 {
     public $controllerNamespace = 'Setka\\Cms\\Http\\Dashboard\\Controllers';
+    public $defaultRoute = 'index';
 
     public function init(): void
     {


### PR DESCRIPTION
## Summary
- set the dashboard module's default route to the index controller so that `/dashboard` resolves to `IndexController::actionIndex`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdffdaa648832d87f3cf1ffadf5f0b