### PR TITLE
feat: add schema builder views

### DIFF
--- a/src/Http/Dashboard/Controllers/SchemasController.php
+++ b/src/Http/Dashboard/Controllers/SchemasController.php
@@ -9,12 +9,435 @@ declare(strict_types=1);
 
 namespace Setka\Cms\Http\Dashboard\Controllers;
 
+use yii\helpers\Url;
 use yii\web\Controller;
 
 final class SchemasController extends Controller
 {
     public function actionIndex(): string
     {
-        return $this->render('index');
+        return $this->render('index', [
+            'schemasDataset' => $this->getDemoSchemasDataset(),
+            'schemasDefaultSavedViews' => $this->getDemoSchemasDefaultSavedViews(),
+        ]);
+    }
+
+    public function actionCreate(): string
+    {
+        return $this->render('create', [
+            'collections' => $this->getSchemaCollections(),
+            'fieldTypes' => $this->getSchemaFieldTypes(),
+            'presets' => $this->getSchemaPresets(),
+        ]);
+    }
+
+    public function actionEditor(?string $schema = null): string
+    {
+        $dataset = $this->getDemoSchemasDataset();
+        $schemaData = null;
+        $schemaId = $schema !== null ? trim($schema) : '';
+        if ($schemaId !== '') {
+            foreach ($dataset as $item) {
+                if (($item['id'] ?? '') === $schemaId || ($item['handle'] ?? '') === $schemaId) {
+                    $schemaData = $item;
+                    break;
+                }
+            }
+        }
+
+        return $this->render('editor', [
+            'schema' => $schemaData,
+            'collections' => $this->getSchemaCollections(),
+            'fieldTypes' => $this->getSchemaFieldTypes(),
+            'presets' => $this->getSchemaPresets(),
+            'requestedSchemaId' => $schemaId,
+            'schemaNotFound' => $schemaId !== '' && $schemaData === null,
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getDemoSchemasDataset(): array
+    {
+        return [
+            [
+                'id' => 'schema-article',
+                'handle' => 'article',
+                'name' => 'Схема «Статья»',
+                'collection' => [
+                    'handle' => 'articles',
+                    'name' => 'Коллекция «Статьи»',
+                    'type' => 'content',
+                ],
+                'description' => 'Шаблон для полноформатных материалов с поддержкой мультимедийных блоков и локализации.',
+                'updated' => '18.03.2025 11:24',
+                'updatedIso' => '2025-03-18T11:24:00+03:00',
+                'editUrl' => Url::to(['/dashboard/schemas/editor', 'schema' => 'schema-article']),
+                'fields' => [
+                    [
+                        'name' => 'Заголовок',
+                        'handle' => 'title',
+                        'type' => 'text',
+                        'required' => true,
+                        'localized' => true,
+                        'description' => 'Основной заголовок материала, отображается на сайте и в соцсетях.',
+                    ],
+                    [
+                        'name' => 'Слаг',
+                        'handle' => 'slug',
+                        'type' => 'slug',
+                        'required' => true,
+                        'description' => 'URL-идентификатор записи, генерируется из заголовка.',
+                    ],
+                    [
+                        'name' => 'Лид',
+                        'handle' => 'lead',
+                        'type' => 'richtext',
+                        'localized' => true,
+                        'description' => 'Короткое описание, которое используется в подборках и рассылках.',
+                    ],
+                    [
+                        'name' => 'Контент',
+                        'handle' => 'content',
+                        'type' => 'matrix',
+                        'required' => true,
+                        'localized' => true,
+                        'description' => 'Основной контент статьи с блоками текста, галереями и цитатами.',
+                    ],
+                    [
+                        'name' => 'Автор',
+                        'handle' => 'author',
+                        'type' => 'relation',
+                        'description' => 'Связь со справочником авторов.',
+                    ],
+                    [
+                        'name' => 'Темы',
+                        'handle' => 'topics',
+                        'type' => 'taxonomy',
+                        'multiple' => true,
+                        'description' => 'Теги и рубрики, которые помогают классифицировать материал.',
+                    ],
+                ],
+                'tags' => ['контент', 'редакция', 'статья'],
+            ],
+            [
+                'id' => 'schema-news',
+                'handle' => 'news',
+                'name' => 'Схема «Новость»',
+                'collection' => [
+                    'handle' => 'newsroom',
+                    'name' => 'Коллекция «Новости»',
+                    'type' => 'content',
+                ],
+                'description' => 'Облегчённый шаблон для оперативных публикаций, ориентированный на скорость выпуска.',
+                'updated' => '04.03.2025 08:05',
+                'updatedIso' => '2025-03-04T08:05:00+03:00',
+                'editUrl' => Url::to(['/dashboard/schemas/editor', 'schema' => 'schema-news']),
+                'fields' => [
+                    [
+                        'name' => 'Заголовок',
+                        'handle' => 'title',
+                        'type' => 'text',
+                        'required' => true,
+                        'description' => 'Короткий заголовок новости.',
+                    ],
+                    [
+                        'name' => 'Слаг',
+                        'handle' => 'slug',
+                        'type' => 'slug',
+                        'required' => true,
+                        'description' => 'URL-иднтификатор.',
+                    ],
+                    [
+                        'name' => 'Анонс',
+                        'handle' => 'excerpt',
+                        'type' => 'textarea',
+                        'description' => 'Вступительный абзац, выводится в лентах.',
+                    ],
+                    [
+                        'name' => 'Источник',
+                        'handle' => 'source_link',
+                        'type' => 'url',
+                        'description' => 'Ссылка на первоисточник новости.',
+                    ],
+                    [
+                        'name' => 'Опубликовано',
+                        'handle' => 'published_at',
+                        'type' => 'datetime',
+                        'required' => true,
+                        'description' => 'Дата и время публикации.',
+                    ],
+                ],
+                'tags' => ['новости', 'оперативно'],
+            ],
+            [
+                'id' => 'schema-product',
+                'handle' => 'product',
+                'name' => 'Схема «Продукт»',
+                'collection' => [
+                    'handle' => 'products',
+                    'name' => 'Каталог «Продукты»',
+                    'type' => 'catalog',
+                ],
+                'description' => 'Схема для карточек товаров с поддержкой характеристик и галерей.',
+                'updated' => '22.02.2025 17:40',
+                'updatedIso' => '2025-02-22T17:40:00+03:00',
+                'editUrl' => Url::to(['/dashboard/schemas/editor', 'schema' => 'schema-product']),
+                'fields' => [
+                    [
+                        'name' => 'Название',
+                        'handle' => 'name',
+                        'type' => 'text',
+                        'required' => true,
+                        'description' => 'Отображается на витрине и в поиске.',
+                    ],
+                    [
+                        'name' => 'Артикул',
+                        'handle' => 'sku',
+                        'type' => 'text',
+                        'required' => true,
+                        'description' => 'Уникальный идентификатор товара.',
+                    ],
+                    [
+                        'name' => 'Цена',
+                        'handle' => 'price',
+                        'type' => 'number',
+                        'required' => true,
+                        'description' => 'Актуальная цена в выбранной валюте.',
+                    ],
+                    [
+                        'name' => 'Галерея',
+                        'handle' => 'gallery',
+                        'type' => 'assets',
+                        'multiple' => true,
+                        'description' => 'Изображения товара.',
+                    ],
+                    [
+                        'name' => 'Характеристики',
+                        'handle' => 'specs',
+                        'type' => 'table',
+                        'description' => 'Ключевые параметры и особенности.',
+                    ],
+                ],
+                'tags' => ['каталог', 'commerce'],
+            ],
+            [
+                'id' => 'schema-author',
+                'handle' => 'author',
+                'name' => 'Схема «Автор»',
+                'collection' => [
+                    'handle' => 'authors',
+                    'name' => 'Справочник «Авторы»',
+                    'type' => 'directory',
+                ],
+                'description' => 'Карточка автора для отображения профиля, контактов и социальных сетей.',
+                'updated' => '12.02.2025 13:15',
+                'updatedIso' => '2025-02-12T13:15:00+03:00',
+                'editUrl' => Url::to(['/dashboard/schemas/editor', 'schema' => 'schema-author']),
+                'fields' => [
+                    [
+                        'name' => 'Имя',
+                        'handle' => 'name',
+                        'type' => 'text',
+                        'required' => true,
+                        'description' => 'Полное имя автора.',
+                    ],
+                    [
+                        'name' => 'Слаг',
+                        'handle' => 'slug',
+                        'type' => 'slug',
+                        'required' => true,
+                        'description' => 'URL-идентификатор профиля.',
+                    ],
+                    [
+                        'name' => 'Фотография',
+                        'handle' => 'photo',
+                        'type' => 'asset',
+                        'description' => 'Портрет автора.',
+                    ],
+                    [
+                        'name' => 'Биография',
+                        'handle' => 'bio',
+                        'type' => 'richtext',
+                        'description' => 'Краткая биография и достижения.',
+                    ],
+                    [
+                        'name' => 'Социальные сети',
+                        'handle' => 'social_links',
+                        'type' => 'matrix',
+                        'multiple' => true,
+                        'description' => 'Ссылки на профили в соцсетях.',
+                    ],
+                ],
+                'tags' => ['справочник', 'команда'],
+            ],
+            [
+                'id' => 'schema-event',
+                'handle' => 'event',
+                'name' => 'Схема «Событие»',
+                'collection' => [
+                    'handle' => 'events',
+                    'name' => 'Коллекция «События»',
+                    'type' => 'calendar',
+                ],
+                'description' => 'Схема для мероприятий, вебинаров и офлайн-активностей.',
+                'updated' => '02.02.2025 09:50',
+                'updatedIso' => '2025-02-02T09:50:00+03:00',
+                'editUrl' => Url::to(['/dashboard/schemas/editor', 'schema' => 'schema-event']),
+                'fields' => [
+                    [
+                        'name' => 'Название',
+                        'handle' => 'title',
+                        'type' => 'text',
+                        'required' => true,
+                        'description' => 'Имя события.',
+                    ],
+                    [
+                        'name' => 'Слаг',
+                        'handle' => 'slug',
+                        'type' => 'slug',
+                        'required' => true,
+                        'description' => 'URL-идентификатор.',
+                    ],
+                    [
+                        'name' => 'Дата начала',
+                        'handle' => 'start_at',
+                        'type' => 'datetime',
+                        'required' => true,
+                        'description' => 'Старт мероприятия.',
+                    ],
+                    [
+                        'name' => 'Локация',
+                        'handle' => 'location',
+                        'type' => 'text',
+                        'description' => 'Место проведения или ссылка на онлайн-площадку.',
+                    ],
+                    [
+                        'name' => 'Регистрация',
+                        'handle' => 'registration',
+                        'type' => 'url',
+                        'description' => 'Ссылка на форму регистрации.',
+                    ],
+                ],
+                'tags' => ['мероприятия', 'календарь'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getDemoSchemasDefaultSavedViews(): array
+    {
+        return [
+            [
+                'id' => 'schemas-default-articles',
+                'name' => 'Материалы редакции',
+                'filters' => [
+                    'collection' => 'articles',
+                    'selected' => 'schema-article',
+                ],
+            ],
+            [
+                'id' => 'schemas-default-news',
+                'name' => 'Экспресс-новости',
+                'filters' => [
+                    'collection' => 'newsroom',
+                    'selected' => 'schema-news',
+                ],
+            ],
+            [
+                'id' => 'schemas-default-products',
+                'name' => 'Каталог продукции',
+                'filters' => [
+                    'collection' => 'products',
+                    'selected' => 'schema-product',
+                ],
+            ],
+            [
+                'id' => 'schemas-default-authors',
+                'name' => 'Справочник авторов',
+                'filters' => [
+                    'collection' => 'authors',
+                    'selected' => 'schema-author',
+                ],
+            ],
+            [
+                'id' => 'schemas-default-events',
+                'name' => 'События и вебинары',
+                'filters' => [
+                    'collection' => 'events',
+                    'selected' => 'schema-event',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function getSchemaCollections(): array
+    {
+        $collections = [];
+        foreach ($this->getDemoSchemasDataset() as $schema) {
+            $collection = $schema['collection'] ?? null;
+            if (!is_array($collection)) {
+                continue;
+            }
+
+            $handle = (string) ($collection['handle'] ?? '');
+            if ($handle === '' || isset($collections[$handle])) {
+                continue;
+            }
+
+            $collections[$handle] = [
+                'handle' => $handle,
+                'name' => (string) ($collection['name'] ?? $handle),
+                'type' => (string) ($collection['type'] ?? ''),
+            ];
+        }
+
+        ksort($collections);
+
+        return array_values($collections);
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function getSchemaFieldTypes(): array
+    {
+        return [
+            ['value' => 'text', 'label' => 'Текстовое поле'],
+            ['value' => 'textarea', 'label' => 'Многострочный текст'],
+            ['value' => 'richtext', 'label' => 'Rich Text'],
+            ['value' => 'number', 'label' => 'Число'],
+            ['value' => 'datetime', 'label' => 'Дата и время'],
+            ['value' => 'relation', 'label' => 'Связь с сущностью'],
+            ['value' => 'taxonomy', 'label' => 'Таксономия'],
+            ['value' => 'assets', 'label' => 'Медиа-файлы'],
+            ['value' => 'matrix', 'label' => 'Набор блоков'],
+            ['value' => 'table', 'label' => 'Таблица'],
+            ['value' => 'slug', 'label' => 'Системный идентификатор'],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getSchemaPresets(): array
+    {
+        $presets = [];
+        foreach ($this->getDemoSchemasDataset() as $schema) {
+            $presets[] = [
+                'id' => (string) ($schema['id'] ?? uniqid('schema-', true)),
+                'name' => (string) ($schema['name'] ?? 'Пресет'),
+                'description' => (string) ($schema['description'] ?? ''),
+                'schema' => $schema,
+            ];
+        }
+
+        return $presets;
     }
 }

--- a/src/Http/Dashboard/Module.php
+++ b/src/Http/Dashboard/Module.php
@@ -86,6 +86,8 @@ class Module extends BaseModule
                 'dashboard/collections/<handle:[A-Za-z0-9\-_]+>/entries/<id:[^/]+>/edit' => 'dashboard/entries/edit',
                 'dashboard/elements/<id:[^/]+>/preview' => 'dashboard/elements/preview',
                 'dashboard/elements/<id:[^/]+>/history' => 'dashboard/elements/history',
+                'dashboard/schemas/create' => 'dashboard/schemas/create',
+                'dashboard/schemas/editor' => 'dashboard/schemas/editor',
             ], false);
         }
 

--- a/src/Http/Dashboard/Views/schemas/_builder.php
+++ b/src/Http/Dashboard/Views/schemas/_builder.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+use yii\\helpers\\Html;
+use yii\\helpers\\Json;
+use yii\\helpers\\Url;
+
+/* @var $this yii\\web\\View */
+/* @var string $mode */
+/* @var array<int, array<string, mixed>> $collections */
+/* @var array<int, array<string, mixed>> $fieldTypes */
+/* @var array<int, array<string, mixed>> $presets */
+/* @var array<string, mixed>|null $schema */
+/* @var string|null $requestedSchemaId */
+/* @var bool|null $schemaNotFound */
+
+$mode = $mode ?? 'create';
+$collections = $collections ?? [];
+$fieldTypes = $fieldTypes ?? [];
+$presets = $presets ?? [];
+$schema = $schema ?? null;
+$requestedSchemaId = $requestedSchemaId ?? '';
+$schemaNotFound = (bool) ($schemaNotFound ?? false);
+
+$indexUrl = Url::to(['index']);
+$createUrl = Url::to(['create']);
+$editorUrl = Url::to(['editor']);
+
+$pendingStorageKey = 'dashboard.schemas.pendingUpdate';
+$datasetStorageKey = 'dashboard.schemas.customDataset';
+
+$builderConfig = [
+    'mode' => $mode,
+    'collections' => $collections,
+    'fieldTypes' => $fieldTypes,
+    'presets' => $presets,
+    'indexUrl' => $indexUrl,
+    'createUrl' => $createUrl,
+    'editorUrl' => $editorUrl,
+    'pendingStorageKey' => $pendingStorageKey,
+    'datasetStorageKey' => $datasetStorageKey,
+];
+
+if (!empty($schema)) {
+    $builderConfig['schema'] = $schema;
+}
+
+if ($requestedSchemaId !== '') {
+    $builderConfig['requestedSchemaId'] = $requestedSchemaId;
+}
+
+$indexUrlJson = Json::htmlEncode($indexUrl);
+$createUrlJson = Json::htmlEncode($createUrl);
+$editorUrlJson = Json::htmlEncode($editorUrl);
+$pendingStorageKeyJson = Json::htmlEncode($pendingStorageKey);
+$datasetStorageKeyJson = Json::htmlEncode($datasetStorageKey);
+
+$this->registerJs(<<<JS
+window.cmsSchemasIndexUrl = {$indexUrlJson};
+window.cmsSchemasCreateUrl = {$createUrlJson};
+window.cmsSchemasEditorUrl = {$editorUrlJson};
+window.cmsSchemasPendingStorageKey = {$pendingStorageKeyJson};
+window.cmsSchemasDatasetStorageKey = {$datasetStorageKeyJson};
+JS);
+?>
+
+<div class="row" data-role="schema-builder-wrapper">
+    <div class="col-md-8">
+        <div class="box box-success">
+            <div class="box-header with-border">
+                <h3 class="box-title">
+                    <?= Html::encode($mode === 'edit' ? 'Редактирование схемы' : 'Новая схема') ?>
+                </h3>
+                <div class="box-tools">
+                    <div class="btn-group btn-group-sm">
+                        <button type="button" class="btn btn-default" data-action="schema-add-field">
+                            <i class="fa fa-plus"></i> Добавить поле
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="box-body">
+                <?php if ($schemaNotFound): ?>
+                    <div class="alert alert-warning" role="alert">
+                        Запрошенная схема <?= Html::tag('strong', Html::encode($requestedSchemaId)) ?> не найдена в демо-данных. Вы можете
+                        создать новую схему — идентификатор будет подставлен автоматически.
+                    </div>
+                <?php endif; ?>
+                <div class="alert alert-info hidden" data-role="schema-builder-feedback" role="alert"></div>
+                <form data-role="schema-builder">
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="form-group">
+                                <label for="schema-name">Название схемы</label>
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="schema-name"
+                                    data-role="schema-name"
+                                    placeholder="Например: Статья"
+                                >
+                                <p class="help-block">Отображается в списках и в интерфейсе редакторов.</p>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="form-group">
+                                <label for="schema-handle">Системный код</label>
+                                <div class="input-group">
+                                    <span class="input-group-addon">@</span>
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        id="schema-handle"
+                                        data-role="schema-handle"
+                                        placeholder="article"
+                                    >
+                                </div>
+                                <p class="help-block">Используется в API и шаблонах. Генерируется автоматически из названия.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="schema-description">Описание</label>
+                        <textarea
+                            class="form-control"
+                            rows="3"
+                            id="schema-description"
+                            data-role="schema-description"
+                            placeholder="Краткое описание назначения схемы"
+                        ></textarea>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="schema-tags">Теги</label>
+                        <input
+                            type="text"
+                            class="form-control"
+                            id="schema-tags"
+                            data-role="schema-tags"
+                            placeholder="Например: контент, редакция"
+                        >
+                        <p class="help-block">Перечислите ключевые слова через запятую — они помогут при поиске.</p>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="schema-collection">Коллекция</label>
+                        <select
+                            id="schema-collection"
+                            class="form-control select2"
+                            data-role="schema-collection"
+                            data-placeholder="Выберите коллекцию"
+                        >
+                            <option value="">Выберите коллекцию</option>
+                        </select>
+                        <p class="help-block">Определяет, где будет доступна схема и какие элементы она описывает.</p>
+                    </div>
+
+                    <hr>
+
+                    <h4 class="text-muted">Поля схемы</h4>
+                    <p class="help-block">
+                        Добавьте поля, чтобы описать структуру записей. Можно задать тип, обязательность и локализацию каждого поля.
+                    </p>
+                    <div class="well well-sm text-muted" data-role="schema-fields-empty">
+                        Пока нет ни одного поля. Добавьте первое поле, чтобы начать настройку схемы.
+                    </div>
+                    <div data-role="schema-fields-list"></div>
+                    <div class="text-right" style="margin-top: 10px;">
+                        <button type="button" class="btn btn-default btn-sm" data-action="schema-add-field">
+                            <i class="fa fa-plus"></i> Добавить поле
+                        </button>
+                    </div>
+                </form>
+            </div>
+            <div class="box-footer clearfix">
+                <div class="pull-left">
+                    <?= Html::a('<i class="fa fa-angle-left"></i> К списку схем', ['index'], [
+                        'class' => 'btn btn-default btn-sm',
+                        'data-pjax' => '0',
+                    ]) ?>
+                </div>
+                <div class="pull-right">
+                    <button type="button" class="btn btn-default" data-action="schema-save-stay">Сохранить и продолжить</button>
+                    <button type="button" class="btn btn-success" data-action="schema-save">
+                        <i class="fa fa-check"></i> Сохранить и выйти
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="box box-solid">
+            <div class="box-header with-border">
+                <h4 class="box-title">Предпросмотр схемы</h4>
+            </div>
+            <div class="box-body">
+                <h4 class="schema-preview-name" data-role="schema-preview-name">Новая схема</h4>
+                <p class="text-muted">
+                    Код: <span data-role="schema-preview-handle">—</span>
+                </p>
+                <p class="text-muted hidden" data-role="schema-preview-description"></p>
+                <dl class="dl-horizontal">
+                    <dt>Коллекция</dt>
+                    <dd data-role="schema-preview-collection">—</dd>
+                    <dt>Поля</dt>
+                    <dd data-role="schema-preview-fields-count">0</dd>
+                </dl>
+                <p class="text-muted" data-role="schema-preview-placeholder">
+                    Добавьте поля, чтобы увидеть структуру схемы и параметры каждого поля.
+                </p>
+                <ul class="list-group" data-role="schema-preview-fields"></ul>
+            </div>
+        </div>
+
+        <?php if (!empty($presets)): ?>
+            <div class="box box-solid">
+                <div class="box-header with-border">
+                    <h4 class="box-title">Готовые пресеты</h4>
+                </div>
+                <div class="box-body">
+                    <p class="text-muted small">
+                        Выберите один из пресетов, чтобы заполнить конструктор демонстрационными данными и ускорить настройку.
+                    </p>
+                    <div class="list-group">
+                        <?php foreach ($presets as $preset): ?>
+                            <?php
+                            $presetId = isset($preset['id']) ? (string) $preset['id'] : '';
+                            if ($presetId === '') {
+                                continue;
+                            }
+                            $presetName = isset($preset['name']) ? (string) $preset['name'] : 'Пресет';
+                            $presetDescription = isset($preset['description']) ? (string) $preset['description'] : '';
+                            ?>
+                            <button
+                                type="button"
+                                class="list-group-item"
+                                data-action="schema-apply-preset"
+                                data-preset-id="<?= Html::encode($presetId) ?>"
+                            >
+                                <strong><?= Html::encode($presetName) ?></strong>
+                                <?php if ($presetDescription !== ''): ?>
+                                    <div class="text-muted small">
+                                        <?= Html::encode($presetDescription) ?>
+                                    </div>
+                                <?php endif; ?>
+                            </button>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<script type="application/json" data-role="schema-builder-config">
+    <?= Json::htmlEncode($builderConfig) . "\n" ?>
+</script>

--- a/src/Http/Dashboard/Views/schemas/create.php
+++ b/src/Http/Dashboard/Views/schemas/create.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\\web\\View */
+/* @var array<int, array<string, mixed>> $collections */
+/* @var array<int, array<string, mixed>> $fieldTypes */
+/* @var array<int, array<string, mixed>> $presets */
+
+$this->title = 'Новая схема';
+$this->params['breadcrumbs'][] = ['label' => 'Схемы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+
+echo $this->render('_builder', [
+    'mode' => 'create',
+    'collections' => $collections,
+    'fieldTypes' => $fieldTypes,
+    'presets' => $presets,
+    'schema' => null,
+    'requestedSchemaId' => '',
+    'schemaNotFound' => false,
+]);

--- a/src/Http/Dashboard/Views/schemas/editor.php
+++ b/src/Http/Dashboard/Views/schemas/editor.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this yii\\web\\View */
+/* @var array<int, array<string, mixed>> $collections */
+/* @var array<int, array<string, mixed>> $fieldTypes */
+/* @var array<int, array<string, mixed>> $presets */
+/* @var array<string, mixed>|null $schema */
+/* @var string|null $requestedSchemaId */
+/* @var bool $schemaNotFound */
+
+$schemaName = null;
+if (isset($schema['name']) && is_string($schema['name']) && $schema['name'] !== '') {
+    $schemaName = $schema['name'];
+}
+
+$this->title = $schemaName !== null ? 'Редактирование: ' . $schemaName : 'Редактирование схемы';
+$this->params['breadcrumbs'][] = ['label' => 'Схемы', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+
+echo $this->render('_builder', [
+    'mode' => 'edit',
+    'collections' => $collections,
+    'fieldTypes' => $fieldTypes,
+    'presets' => $presets,
+    'schema' => $schema,
+    'requestedSchemaId' => $requestedSchemaId ?? '',
+    'schemaNotFound' => $schemaNotFound,
+]);

--- a/src/Http/Dashboard/Views/schemas/index.php
+++ b/src/Http/Dashboard/Views/schemas/index.php
@@ -4,321 +4,46 @@ declare(strict_types=1);
 
 use yii\helpers\Html;
 use yii\helpers\Json;
+use yii\helpers\Url;
 
 /* @var $this yii\web\View */
+/* @var array<int, array<string, mixed>> $schemasDataset */
+/* @var array<int, array<string, mixed>> $schemasDefaultSavedViews */
 
 $this->title = 'Схемы данных';
 $this->params['breadcrumbs'][] = $this->title;
 
-$schemasDataset = [
-    [
-        'id' => 'schema-article',
-        'name' => 'Схема «Статья»',
-        'collection' => [
-            'handle' => 'articles',
-            'name' => 'Коллекция «Статьи»',
-            'type' => 'content',
-        ],
-        'description' => 'Шаблон для полноформатных материалов с поддержкой мультимедийных блоков и локализации.',
-        'updated' => '18.03.2025 11:24',
-        'updatedIso' => '2025-03-18T11:24:00+03:00',
-        'editUrl' => '/dashboard/schemas/editor?schema=schema-article',
-        'fields' => [
-            [
-                'name' => 'Заголовок',
-                'handle' => 'title',
-                'type' => 'text',
-                'required' => true,
-                'localized' => true,
-                'description' => 'Основной заголовок материала, отображается на сайте и в соцсетях.',
-            ],
-            [
-                'name' => 'Слаг',
-                'handle' => 'slug',
-                'type' => 'slug',
-                'required' => true,
-                'description' => 'URL-идентификатор записи, генерируется из заголовка.',
-            ],
-            [
-                'name' => 'Лид',
-                'handle' => 'lead',
-                'type' => 'richtext',
-                'localized' => true,
-                'description' => 'Короткое описание, которое используется в подборках и рассылках.',
-            ],
-            [
-                'name' => 'Контент',
-                'handle' => 'content',
-                'type' => 'matrix',
-                'required' => true,
-                'localized' => true,
-                'description' => 'Основной контент статьи с блоками текста, галереями и цитатами.',
-            ],
-            [
-                'name' => 'Автор',
-                'handle' => 'author',
-                'type' => 'relation',
-                'description' => 'Связь со справочником авторов.',
-            ],
-            [
-                'name' => 'Темы',
-                'handle' => 'topics',
-                'type' => 'taxonomy',
-                'multiple' => true,
-                'description' => 'Теги и рубрики, которые помогают классифицировать материал.',
-            ],
-        ],
-        'tags' => ['контент', 'редакция', 'статья'],
-    ],
-    [
-        'id' => 'schema-news',
-        'name' => 'Схема «Новость»',
-        'collection' => [
-            'handle' => 'newsroom',
-            'name' => 'Коллекция «Новости»',
-            'type' => 'content',
-        ],
-        'description' => 'Облегчённый шаблон для оперативных публикаций, ориентированный на скорость выпуска.',
-        'updated' => '04.03.2025 08:05',
-        'updatedIso' => '2025-03-04T08:05:00+03:00',
-        'editUrl' => '/dashboard/schemas/editor?schema=schema-news',
-        'fields' => [
-            [
-                'name' => 'Заголовок',
-                'handle' => 'title',
-                'type' => 'text',
-                'required' => true,
-                'description' => 'Короткий заголовок новости.',
-            ],
-            [
-                'name' => 'Слаг',
-                'handle' => 'slug',
-                'type' => 'slug',
-                'required' => true,
-                'description' => 'URL-идентификатор.',
-            ],
-            [
-                'name' => 'Анонс',
-                'handle' => 'excerpt',
-                'type' => 'textarea',
-                'description' => 'Вступительный абзац, выводится в лентах.',
-            ],
-            [
-                'name' => 'Источник',
-                'handle' => 'source_link',
-                'type' => 'url',
-                'description' => 'Ссылка на первоисточник новости.',
-            ],
-            [
-                'name' => 'Опубликовано',
-                'handle' => 'published_at',
-                'type' => 'datetime',
-                'required' => true,
-                'description' => 'Дата и время публикации.',
-            ],
-        ],
-        'tags' => ['новости', 'оперативно'],
-    ],
-    [
-        'id' => 'schema-product',
-        'name' => 'Схема «Продукт»',
-        'collection' => [
-            'handle' => 'products',
-            'name' => 'Каталог «Продукты»',
-            'type' => 'catalog',
-        ],
-        'description' => 'Схема для карточек товаров с поддержкой характеристик и галерей.',
-        'updated' => '22.02.2025 17:40',
-        'updatedIso' => '2025-02-22T17:40:00+03:00',
-        'editUrl' => '/dashboard/schemas/editor?schema=schema-product',
-        'fields' => [
-            [
-                'name' => 'Название',
-                'handle' => 'name',
-                'type' => 'text',
-                'required' => true,
-                'description' => 'Отображается на витрине и в поиске.',
-            ],
-            [
-                'name' => 'Артикул',
-                'handle' => 'sku',
-                'type' => 'text',
-                'required' => true,
-                'description' => 'Уникальный идентификатор товара.',
-            ],
-            [
-                'name' => 'Цена',
-                'handle' => 'price',
-                'type' => 'number',
-                'required' => true,
-                'description' => 'Актуальная цена в выбранной валюте.',
-            ],
-            [
-                'name' => 'Галерея',
-                'handle' => 'gallery',
-                'type' => 'assets',
-                'multiple' => true,
-                'description' => 'Изображения товара.',
-            ],
-            [
-                'name' => 'Характеристики',
-                'handle' => 'specs',
-                'type' => 'table',
-                'description' => 'Ключевые параметры и особенности.',
-            ],
-        ],
-        'tags' => ['каталог', 'commerce'],
-    ],
-    [
-        'id' => 'schema-author',
-        'name' => 'Схема «Автор»',
-        'collection' => [
-            'handle' => 'authors',
-            'name' => 'Справочник «Авторы»',
-            'type' => 'directory',
-        ],
-        'description' => 'Карточка автора для отображения профиля, контактов и социальных сетей.',
-        'updated' => '12.02.2025 13:15',
-        'updatedIso' => '2025-02-12T13:15:00+03:00',
-        'editUrl' => '/dashboard/schemas/editor?schema=schema-author',
-        'fields' => [
-            [
-                'name' => 'Имя',
-                'handle' => 'name',
-                'type' => 'text',
-                'required' => true,
-                'description' => 'Полное имя автора.',
-            ],
-            [
-                'name' => 'Слаг',
-                'handle' => 'slug',
-                'type' => 'slug',
-                'required' => true,
-                'description' => 'URL-идентификатор профиля.',
-            ],
-            [
-                'name' => 'Фотография',
-                'handle' => 'photo',
-                'type' => 'asset',
-                'description' => 'Портрет автора.',
-            ],
-            [
-                'name' => 'Биография',
-                'handle' => 'bio',
-                'type' => 'richtext',
-                'description' => 'Краткая биография и достижения.',
-            ],
-            [
-                'name' => 'Социальные сети',
-                'handle' => 'social_links',
-                'type' => 'matrix',
-                'multiple' => true,
-                'description' => 'Ссылки на профили в соцсетях.',
-            ],
-        ],
-        'tags' => ['справочник', 'команда'],
-    ],
-    [
-        'id' => 'schema-event',
-        'name' => 'Схема «Событие»',
-        'collection' => [
-            'handle' => 'events',
-            'name' => 'Коллекция «События»',
-            'type' => 'calendar',
-        ],
-        'description' => 'Схема для мероприятий, вебинаров и офлайн-активностей.',
-        'updated' => '02.02.2025 09:50',
-        'updatedIso' => '2025-02-02T09:50:00+03:00',
-        'editUrl' => '/dashboard/schemas/editor?schema=schema-event',
-        'fields' => [
-            [
-                'name' => 'Название',
-                'handle' => 'title',
-                'type' => 'text',
-                'required' => true,
-                'description' => 'Имя события.',
-            ],
-            [
-                'name' => 'Слаг',
-                'handle' => 'slug',
-                'type' => 'slug',
-                'required' => true,
-                'description' => 'URL-идентификатор.',
-            ],
-            [
-                'name' => 'Дата начала',
-                'handle' => 'start_at',
-                'type' => 'datetime',
-                'required' => true,
-                'description' => 'Старт мероприятия.',
-            ],
-            [
-                'name' => 'Локация',
-                'handle' => 'location',
-                'type' => 'text',
-                'description' => 'Место проведения или ссылка на онлайн-площадку.',
-            ],
-            [
-                'name' => 'Регистрация',
-                'handle' => 'registration',
-                'type' => 'url',
-                'description' => 'Ссылка на форму регистрации.',
-            ],
-        ],
-        'tags' => ['мероприятия', 'календарь'],
-    ],
-];
+$schemasDataset = $schemasDataset ?? [];
+$schemasDefaultSavedViews = $schemasDefaultSavedViews ?? [];
 
-$schemasDefaultSavedViews = [
-    [
-        'id' => 'schemas-default-articles',
-        'name' => 'Материалы редакции',
-        'filters' => [
-            'collection' => 'articles',
-            'selected' => 'schema-article',
-        ],
-    ],
-    [
-        'id' => 'schemas-default-news',
-        'name' => 'Экспресс-новости',
-        'filters' => [
-            'collection' => 'newsroom',
-            'selected' => 'schema-news',
-        ],
-    ],
-    [
-        'id' => 'schemas-default-products',
-        'name' => 'Каталог продукции',
-        'filters' => [
-            'collection' => 'products',
-            'selected' => 'schema-product',
-        ],
-    ],
-    [
-        'id' => 'schemas-default-authors',
-        'name' => 'Справочник авторов',
-        'filters' => [
-            'collection' => 'authors',
-            'selected' => 'schema-author',
-        ],
-    ],
-    [
-        'id' => 'schemas-default-events',
-        'name' => 'События и вебинары',
-        'filters' => [
-            'collection' => 'events',
-            'selected' => 'schema-event',
-        ],
-    ],
-];
+$indexUrl = Url::to(['index']);
+$createUrl = Url::to(['create']);
+$editorUrl = Url::to(['editor']);
+
+$pendingStorageKey = 'dashboard.schemas.pendingUpdate';
+$datasetStorageKey = 'dashboard.schemas.customDataset';
+
+$indexUrlJson = Json::htmlEncode($indexUrl);
+$createUrlJson = Json::htmlEncode($createUrl);
+$editorUrlJson = Json::htmlEncode($editorUrl);
+$pendingStorageKeyJson = Json::htmlEncode($pendingStorageKey);
+$datasetStorageKeyJson = Json::htmlEncode($datasetStorageKey);
+
+$this->registerJs(<<<JS
+window.cmsSchemasIndexUrl = {$indexUrlJson};
+window.cmsSchemasCreateUrl = {$createUrlJson};
+window.cmsSchemasEditorUrl = {$editorUrlJson};
+window.cmsSchemasPendingStorageKey = {$pendingStorageKeyJson};
+window.cmsSchemasDatasetStorageKey = {$datasetStorageKeyJson};
+JS);
 ?>
 
-<div class="box box-primary" data-role="schemas">
+<div class="box box-primary" data-role="schemas" data-index-url="<?= Html::encode($indexUrl) ?>" data-create-url="<?= Html::encode($createUrl) ?>" data-editor-url="<?= Html::encode($editorUrl) ?>">
     <div class="box-header with-border">
         <h3 class="box-title">Конструктор схем</h3>
         <div class="box-tools">
             <div class="btn-group btn-group-sm">
-                <button type="button" class="btn btn-success" data-action="create-schema">
+                <button type="button" class="btn btn-success" data-action="create-schema" data-create-url="<?= Html::encode($createUrl) ?>">
                     <i class="fa fa-plus"></i> Новая схема
                 </button>
                 <button type="button" class="btn btn-default" data-action="import-schema">
@@ -412,6 +137,7 @@ $schemasDefaultSavedViews = [
                         <?= Html::a('<i class="fa fa-pencil"></i> Редактировать', '#', [
                             'class' => 'btn btn-primary btn-sm disabled',
                             'data-role' => 'edit-schema',
+                            'data-pjax' => '0',
                         ]) ?>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- wire up schema create and edit actions in the dashboard controller and module
- add dedicated builder views with reusable partial and preview widgets
- expose schema dataset/config to the UI and adjust dashboard scripts for navigation and saved state

## Testing
- composer test *(fails: phpunit not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9998cea4832db8e5783f45a14c59