### PR TITLE
feat: load page-specific dashboard scripts

### DIFF
--- a/src/Http/Dashboard/Assets/js/core/bootstrap-runner.js
+++ b/src/Http/Dashboard/Assets/js/core/bootstrap-runner.js
@@ -1,0 +1,5 @@
+import bootstrap from './bootstrap.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    bootstrap();
+});

--- a/src/Http/Dashboard/Views/layouts/main.php
+++ b/src/Http/Dashboard/Views/layouts/main.php
@@ -13,6 +13,20 @@ if (Yii::$app->controller->action->id === 'login') {
     );
     return;
 }
+/** @var yii\web\Controller|null $controller */
+$controller = Yii::$app->controller;
+$pageId = null;
+
+if ($controller !== null && $controller->action !== null) {
+    $pageId = DashboardAsset::formatPageId($controller->id, $controller->action->id);
+
+    if ($pageId !== '') {
+        $this->params[DashboardAsset::PAGE_ID_PARAM] = $pageId;
+    } else {
+        $pageId = null;
+    }
+}
+
 DashboardAsset::register($this);
 $directoryAsset = Yii::$app->assetManager->getPublishedUrl('@vendor/almasaeed2010/adminlte/dist');
 ?>
@@ -27,7 +41,16 @@ $directoryAsset = Yii::$app->assetManager->getPublishedUrl('@vendor/almasaeed201
     <link href="https://fonts.cdnfonts.com/css/pt-root-ui" rel="stylesheet">
     <?php $this->head() ?>
 </head>
-<body class="skin-blue sidebar-mini">
+<?php
+$bodyAttributes = [
+    'class' => 'skin-blue sidebar-mini',
+];
+
+if ($pageId !== null) {
+    $bodyAttributes['data-page'] = $pageId;
+}
+?>
+<body <?= Html::renderTagAttributes($bodyAttributes) ?>>
 <?php $this->beginBody() ?>
 <div class="wrapper">
 


### PR DESCRIPTION
## Summary
- add a data-page attribute in the main dashboard layout to expose the current page identifier
- update DashboardAsset to resolve the page id, load the matching module bundle and bootstrap runner module
- add a small bootstrap runner module that triggers dashboard initialisation on DOM ready

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceba801914832da38f819a141e7252