### PR TITLE
Добавить страницу просмотра ассетов медиатеки

### DIFF
--- a/src/Http/Dashboard/Assets/js/core/legacy.js
+++ b/src/Http/Dashboard/Assets/js/core/legacy.js
@@ -61,6 +61,7 @@ const Dashboard = {
         mediaLibraryFilters: null,
         mediaLibrarySelection: [],
         mediaLibraryViewMode: 'grid',
+        mediaViewUrlTemplate: '',
         taxonomyDataset: null,
         taxonomyCurrentHandle: '',
         taxonomySortableInstances: [],
@@ -6205,6 +6206,8 @@ const Dashboard = {
                 $library.data('mediaLibraryInitialized', true);
             }
 
+            this.mediaViewUrlTemplate = String($library.data('mediaViewUrlTemplate') || '').replace(/&amp;/g, '&');
+
             this.getMediaAssets().done(function (assets) {
                 self.mediaLibraryFilters = {
                     search: '',
@@ -6244,7 +6247,11 @@ const Dashboard = {
                     collection: 'articles',
                     collectionName: 'Статьи',
                     tags: ['editorial', 'workflow'],
-                    createdAt: '2025-03-08T10:15:00+03:00'
+                    description: 'Динамичный снимок рабочей команды для презентаций и внутренних отчётов.',
+                    alt: 'Команда за работой в редакции',
+                    source: 'Внутренний фотобанк',
+                    createdAt: '2025-03-08T10:15:00+03:00',
+                    updatedAt: '2025-03-08T11:20:00+03:00'
                 },
                 {
                     id: 'asset-502',
@@ -6260,7 +6267,11 @@ const Dashboard = {
                     collection: 'news',
                     collectionName: 'Новости',
                     tags: ['promo', 'homepage'],
-                    createdAt: '2025-02-21T08:50:00+03:00'
+                    description: 'Основной промо-баннер весенней кампании для главной страницы сайта.',
+                    alt: 'Весенний промо-баннер',
+                    source: 'Маркетинговый отдел',
+                    createdAt: '2025-02-21T08:50:00+03:00',
+                    updatedAt: '2025-03-01T09:10:00+03:00'
                 },
                 {
                     id: 'asset-503',
@@ -6275,7 +6286,11 @@ const Dashboard = {
                     collection: 'interviews',
                     collectionName: 'Интервью',
                     tags: ['branding', 'events'],
-                    createdAt: '2025-03-02T12:00:00+03:00'
+                    description: 'Видеоролик с историей бренда, используемый для внешних анонсов и презентаций.',
+                    alt: 'Превью ролика Brand story',
+                    source: 'PR-команда',
+                    createdAt: '2025-03-02T12:00:00+03:00',
+                    updatedAt: '2025-03-05T14:00:00+03:00'
                 },
                 {
                     id: 'asset-504',
@@ -6287,7 +6302,11 @@ const Dashboard = {
                     collection: 'articles',
                     collectionName: 'Статьи',
                     tags: ['workflow', 'guideline'],
-                    createdAt: '2025-01-16T14:35:00+03:00'
+                    description: 'PDF-руководство с обновлёнными правилами и стандартами работы редакции.',
+                    alt: 'Редакторский гайд 2025',
+                    source: 'Редакционный отдел',
+                    createdAt: '2025-01-16T14:35:00+03:00',
+                    updatedAt: '2025-02-01T10:05:00+03:00'
                 },
                 {
                     id: 'asset-505',
@@ -6300,7 +6319,11 @@ const Dashboard = {
                     collection: 'articles',
                     collectionName: 'Статьи',
                     tags: ['podcast', 'audio'],
-                    createdAt: '2025-02-10T18:05:00+03:00'
+                    description: 'Короткий аудиотрек для заставки корпоративного подкаста.',
+                    alt: 'Аудиофайл podcast intro',
+                    source: 'Звукорежиссёр студии',
+                    createdAt: '2025-02-10T18:05:00+03:00',
+                    updatedAt: '2025-02-15T12:45:00+03:00'
                 },
                 {
                     id: 'asset-506',
@@ -6316,7 +6339,11 @@ const Dashboard = {
                     collection: 'articles',
                     collectionName: 'Статьи',
                     tags: ['newsletter', 'promo'],
-                    createdAt: '2025-03-06T09:40:00+03:00'
+                    description: 'Изображение для мартовской email-рассылки в фирменном стиле.',
+                    alt: 'Обложка мартовской рассылки',
+                    source: 'Дизайн-команда',
+                    createdAt: '2025-03-06T09:40:00+03:00',
+                    updatedAt: '2025-03-06T10:00:00+03:00'
                 },
                 {
                     id: 'asset-507',
@@ -6332,7 +6359,11 @@ const Dashboard = {
                     collection: 'interviews',
                     collectionName: 'Интервью',
                     tags: ['culture', 'people'],
-                    createdAt: '2025-02-28T11:20:00+03:00'
+                    description: 'Фотография команды для материалов о корпоративной культуре.',
+                    alt: 'Редакционная команда на встрече',
+                    source: 'HR-служба',
+                    createdAt: '2025-02-28T11:20:00+03:00',
+                    updatedAt: '2025-03-04T09:30:00+03:00'
                 },
                 {
                     id: 'asset-508',
@@ -6344,7 +6375,11 @@ const Dashboard = {
                     collection: 'news',
                     collectionName: 'Новости',
                     tags: ['press', 'kit'],
-                    createdAt: '2024-12-18T16:10:00+03:00'
+                    description: 'Архив с медиакитом, логотипами и материалами для прессы.',
+                    alt: 'Архив с медиакитом 2025',
+                    source: 'PR-команда',
+                    createdAt: '2024-12-18T16:10:00+03:00',
+                    updatedAt: '2025-01-05T10:00:00+03:00'
                 },
                 {
                     id: 'asset-509',
@@ -6359,7 +6394,11 @@ const Dashboard = {
                     collection: 'interviews',
                     collectionName: 'Интервью',
                     tags: ['video', 'product'],
-                    createdAt: '2025-03-03T15:25:00+03:00'
+                    description: 'Видео-фрагмент интервью с продуктовым менеджером.',
+                    alt: 'Превью интервью с менеджером',
+                    source: 'Видеоотдел',
+                    createdAt: '2025-03-03T15:25:00+03:00',
+                    updatedAt: '2025-03-04T08:45:00+03:00'
                 },
                 {
                     id: 'asset-510',
@@ -6375,7 +6414,11 @@ const Dashboard = {
                     collection: 'news',
                     collectionName: 'Новости',
                     tags: ['analytics', 'report'],
-                    createdAt: '2025-01-28T10:05:00+03:00'
+                    description: 'Инфографика с ключевыми метриками квартального отчёта.',
+                    alt: 'Инфографика с основными метриками',
+                    source: 'Аналитический отдел',
+                    createdAt: '2025-01-28T10:05:00+03:00',
+                    updatedAt: '2025-02-02T09:15:00+03:00'
                 }
             ];
 
@@ -6494,6 +6537,10 @@ const Dashboard = {
             });
 
             $library.on('click', '[data-role="media-item"]', function (event) {
+                if ($(event.target).closest('[data-role="media-open"]').length) {
+                    return;
+                }
+
                 if ($(event.target).is('button, a, i')) {
                     return;
                 }
@@ -6626,16 +6673,7 @@ const Dashboard = {
                 if (asset.type === 'image' && asset.thumb) {
                     $preview.append($('<img>').attr('src', asset.thumb).attr('alt', asset.title));
                 } else {
-                    var icon = 'file-o';
-                    if (asset.type === 'video') {
-                        icon = 'film';
-                    } else if (asset.type === 'audio') {
-                        icon = 'music';
-                    } else if (asset.type === 'document') {
-                        icon = 'file-text-o';
-                    } else if (asset.type === 'archive') {
-                        icon = 'archive';
-                    }
+                    var icon = self.getMediaTypeIcon(asset.type);
                     $preview.append('<div class="media-library__icon"><i class="fa fa-' + icon + '"></i></div>');
                 }
                 $card.append($preview);
@@ -6659,6 +6697,17 @@ const Dashboard = {
                 }
 
                 $caption.append($('<div class="media-library__meta text-muted"></div>').text(meta.join(' • ')));
+
+                var viewUrl = self.getMediaViewUrl(asset.id);
+                if (viewUrl) {
+                    var $actions = $('<div class="media-library__actions text-right"></div>');
+                    var $viewButton = $('<a class="btn btn-xs btn-default" data-role="media-open"></a>')
+                        .attr('href', viewUrl)
+                        .attr('data-pjax', '0')
+                        .html('<i class="fa fa-pencil"></i> Открыть');
+                    $actions.append($viewButton);
+                    $caption.append($actions);
+                }
                 $card.append($caption);
                 $col.append($card);
                 $container.append($col);
@@ -6699,8 +6748,369 @@ const Dashboard = {
 
                 var $meta = $('<div class="media-library__list-meta text-muted"></div>').text(metaParts.join(' • '));
                 $row.append($title).append($meta);
+
+                var viewUrl = self.getMediaViewUrl(asset.id);
+                if (viewUrl) {
+                    var $actions = $('<div class="media-library__list-actions pull-right"></div>');
+                    var $viewLink = $('<a class="btn btn-xs btn-default" data-role="media-open"></a>')
+                        .attr('href', viewUrl)
+                        .attr('data-pjax', '0')
+                        .html('<i class="fa fa-pencil"></i>');
+                    $actions.append($viewLink);
+                    $row.append($actions);
+                }
                 $container.append($row);
             });
+        },
+
+        initMediaViewModule: function (context) {
+            var $context = this.resolveContext(context);
+            var $view = this.findInContext($context, '[data-role="media-view"]').first();
+            if (!$view.length) {
+                return;
+            }
+
+            if ($view.data('mediaViewInitialized')) {
+                return;
+            }
+
+            $view.data('mediaViewInitialized', true);
+
+            var assetId = String($view.data('assetId') || '');
+            if (!assetId) {
+                this.showMediaViewError($view, 'Ассет не найден.');
+                return;
+            }
+
+            var self = this;
+            this.getMediaAssets().done(function () {
+                var asset = self.findMediaAsset(assetId);
+                if (!asset) {
+                    self.showMediaViewError($view, 'Ассет не найден в библиотеке.');
+                    return;
+                }
+
+                self.populateMediaView($view, asset);
+                self.bindMediaViewForm($view, asset);
+            });
+        },
+
+        populateMediaView: function ($view, asset) {
+            if (!$view || !$view.length) {
+                return;
+            }
+
+            var $error = $view.find('[data-role="media-error"]');
+            if ($error.length) {
+                $error.hide().text('');
+            }
+
+            var $form = $view.find('[data-role="media-form"]');
+            if ($form.length) {
+                var $idInput = $form.find('[name="id"]');
+                if ($idInput.length) {
+                    $idInput.val(asset.id || '');
+                }
+
+                $form.find('[name="title"]').val(asset.title || '');
+                $form.find('[name="description"]').val(asset.description || '');
+                $form.find('[name="collection"]').val(asset.collection || '').trigger('change.select2');
+
+                var tags = asset.tags || [];
+                $form.find('[name="tags[]"]').val(tags).trigger('change.select2');
+                $form.find('[name="alt"]').val(asset.alt || '');
+                $form.find('[name="source"]').val(asset.source || '');
+            }
+
+            this.clearMediaFormErrors($form);
+            this.showMediaFormAlert($view, null, null);
+            this.refreshMediaViewSummary($view, asset);
+            $view.data('mediaAsset', asset);
+        },
+
+        refreshMediaViewSummary: function ($view, asset) {
+            if (!$view || !$view.length) {
+                return;
+            }
+
+            var title = asset.title || asset.filename || asset.id || '';
+            if (title) {
+                $view.find('[data-role="media-heading"]').text(title);
+            }
+
+            var $previewContainer = $view.find('[data-role="media-preview"]');
+            var $image = $previewContainer.find('[data-role="media-preview-image"]');
+            var $placeholder = $previewContainer.find('[data-role="media-preview-placeholder"]');
+            var preview = asset.preview || asset.thumb || '';
+            if (asset.type === 'image' && !preview) {
+                preview = asset.url || '';
+            }
+
+            if (preview) {
+                if (!$image.length) {
+                    $image = $('<img class="img-responsive img-rounded" data-role="media-preview-image">');
+                    $previewContainer.empty().append($image);
+                    $placeholder = $();
+                }
+
+                $image.attr('src', preview).attr('alt', asset.alt || title).show();
+                if ($placeholder.length) {
+                    $placeholder.hide();
+                }
+            } else {
+                if ($image.length) {
+                    $image.hide();
+                }
+
+                if (!$placeholder.length) {
+                    $placeholder = $('<div class="media-preview__placeholder text-center text-muted" data-role="media-preview-placeholder"></div>');
+                    $placeholder.append('<i class="fa fa-' + this.getMediaTypeIcon(asset.type) + ' fa-3x" data-role="media-preview-icon"></i>');
+                    $placeholder.append('<p class="small">Предпросмотр появится после загрузки файла.</p>');
+                    $previewContainer.empty().append($placeholder);
+                } else {
+                    $placeholder.show();
+                    var $icon = $placeholder.find('[data-role="media-preview-icon"]');
+                    if ($icon.length) {
+                        $icon.attr('class', 'fa fa-' + this.getMediaTypeIcon(asset.type) + ' fa-3x');
+                    }
+                }
+            }
+
+            var sizeLabel = this.formatFileSize(asset.size) || '—';
+            var durationLabel = this.formatMediaDuration(asset.duration) || '—';
+            var dimensionsLabel = (asset.width && asset.height)
+                ? asset.width + ' × ' + asset.height + ' px'
+                : '—';
+
+            $view.find('[data-role="meta-filename"]').text(asset.filename || '—');
+            $view.find('[data-role="meta-type"]').text(this.getMediaTypeLabel(asset.type));
+            $view.find('[data-role="meta-size"]').text(sizeLabel);
+            $view.find('[data-role="meta-dimensions"]').text(dimensionsLabel);
+            $view.find('[data-role="meta-duration"]').text(durationLabel);
+            $view.find('[data-role="meta-collection"]').text(asset.collectionName || asset.collection || '—');
+            $view.find('[data-role="meta-tags"]').text((asset.tags && asset.tags.length) ? asset.tags.join(', ') : '—');
+            $view.find('[data-role="meta-description"]').text(asset.description || '—');
+            $view.find('[data-role="meta-created"]').text(this.formatDateTimeLabel(asset.createdAt) || '—');
+            $view.find('[data-role="meta-updated"]').text(this.formatDateTimeLabel(asset.updatedAt) || '—');
+
+            var $metaUrl = $view.find('[data-role="meta-url"]');
+            if ($metaUrl.length) {
+                if (asset.url) {
+                    var $link = $metaUrl.find('a');
+                    if (!$link.length) {
+                        $link = $('<a target="_blank" rel="noopener noreferrer"></a>');
+                        $metaUrl.empty().append($link);
+                    }
+                    $link.attr('href', asset.url).text(asset.url);
+                } else {
+                    $metaUrl.text('—');
+                }
+            }
+
+            var $download = $view.find('[data-role="media-download"]');
+            if ($download.length) {
+                if (asset.url) {
+                    $download.attr('href', asset.url).removeClass('disabled');
+                } else {
+                    $download.attr('href', '#').addClass('disabled');
+                }
+            }
+        },
+
+        bindMediaViewForm: function ($view, asset) {
+            if (!$view || !$view.length) {
+                return;
+            }
+
+            var self = this;
+            var $form = $view.find('[data-role="media-form"]');
+            if (!$form.length) {
+                return;
+            }
+
+            $form.off('submit.mediaView').on('submit.mediaView', function (event) {
+                event.preventDefault();
+
+                var $submit = $form.find('[data-role="media-save"]');
+                if ($submit.length) {
+                    $submit.prop('disabled', true);
+                }
+
+                self.clearMediaFormErrors($form);
+                self.showMediaFormAlert($view, null, null);
+
+                var data = self.serializeMediaForm($form);
+                if (!data.collectionName && asset.collectionName) {
+                    data.collectionName = asset.collectionName;
+                }
+
+                var errors = self.validateMediaForm(data);
+                if (errors.length) {
+                    self.showMediaFormErrors($form, errors);
+                    self.showMediaFormAlert($view, 'danger', 'Проверьте правильность заполнения формы.');
+                    if ($submit.length) {
+                        $submit.prop('disabled', false);
+                    }
+                    return;
+                }
+
+                window.setTimeout(function () {
+                    asset.title = data.title;
+                    asset.description = data.description;
+                    asset.collection = data.collection;
+                    asset.collectionName = data.collectionName;
+                    asset.tags = data.tags;
+                    asset.alt = data.alt;
+                    asset.source = data.source;
+                    asset.updatedAt = new Date().toISOString();
+
+                    self.updateMediaAsset(asset);
+                    self.populateMediaView($view, asset);
+                    self.showMediaFormAlert($view, 'success', 'Изменения сохранены.');
+
+                    if ($submit.length) {
+                        $submit.prop('disabled', false);
+                    }
+                }, 200);
+            });
+
+            $view.find('[data-action="media-reset"]').off('click.mediaView').on('click.mediaView', function (event) {
+                event.preventDefault();
+                self.populateMediaView($view, asset);
+                self.showMediaFormAlert($view, 'info', 'Изменения отменены.');
+            });
+        },
+
+        serializeMediaForm: function ($form) {
+            var payload = {
+                id: '',
+                title: '',
+                description: '',
+                collection: '',
+                collectionName: '',
+                tags: [],
+                alt: '',
+                source: ''
+            };
+
+            if (!$form || !$form.length) {
+                return payload;
+            }
+
+            payload.id = $.trim(String($form.find('[name="id"]').val() || ''));
+            payload.title = $.trim(String($form.find('[name="title"]').val() || ''));
+            payload.description = $.trim(String($form.find('[name="description"]').val() || ''));
+
+            var $collection = $form.find('[name="collection"]');
+            payload.collection = $.trim(String($collection.val() || ''));
+            var $selectedOption = $collection.find('option:selected').first();
+            if ($selectedOption.length) {
+                payload.collectionName = $.trim($selectedOption.text());
+            }
+
+            var tags = $form.find('[name="tags[]"]').val() || [];
+            if (!$.isArray(tags)) {
+                tags = [tags];
+            }
+            payload.tags = tags
+                .map(function (tag) { return $.trim(String(tag || '')); })
+                .filter(function (tag) { return tag !== ''; });
+
+            payload.alt = $.trim(String($form.find('[name="alt"]').val() || ''));
+            payload.source = $.trim(String($form.find('[name="source"]').val() || ''));
+
+            return payload;
+        },
+
+        validateMediaForm: function (data) {
+            var errors = [];
+
+            if (!data.title) {
+                errors.push({ field: 'title', message: 'Укажите название файла.' });
+            }
+
+            if (!data.collection) {
+                errors.push({ field: 'collection', message: 'Выберите коллекцию.' });
+            }
+
+            return errors;
+        },
+
+        clearMediaFormErrors: function ($form) {
+            if (!$form || !$form.length) {
+                return;
+            }
+
+            $form.find('.form-group').removeClass('has-error');
+            $form.find('[data-role="field-error"]').each(function () {
+                $(this).text('').hide();
+            });
+        },
+
+        showMediaFormErrors: function ($form, errors) {
+            if (!$form || !$form.length) {
+                return;
+            }
+
+            errors.forEach(function (error) {
+                var field = error.field;
+                var message = error.message || 'Поле заполнено некорректно.';
+                var $group = $form.find('[data-field="' + field + '"]');
+                if (!$group.length) {
+                    return;
+                }
+
+                $group.addClass('has-error');
+                var $error = $group.find('[data-role="field-error"]');
+                if ($error.length) {
+                    $error.text(message).show();
+                }
+            });
+        },
+
+        showMediaFormAlert: function ($view, type, message) {
+            if (!$view || !$view.length) {
+                return;
+            }
+
+            var $alert = $view.find('[data-role="media-alert"]');
+            if (!$alert.length) {
+                return;
+            }
+
+            if (!type || !message) {
+                $alert.removeClass('alert-success alert-danger alert-info alert-warning').hide();
+                return;
+            }
+
+            var normalized = String(type === 'error' ? 'danger' : type);
+            if (['success', 'danger', 'info', 'warning'].indexOf(normalized) === -1) {
+                normalized = 'info';
+            }
+
+            $alert
+                .removeClass('alert-success alert-danger alert-info alert-warning')
+                .addClass('alert-' + normalized)
+                .text(message)
+                .show();
+        },
+
+        showMediaViewError: function ($view, message) {
+            if (!$view || !$view.length) {
+                return;
+            }
+
+            var $error = $view.find('[data-role="media-error"]');
+            if ($error.length) {
+                $error.text(message || 'Не удалось загрузить данные.').show();
+            }
+
+            var $form = $view.find('[data-role="media-form"]');
+            if ($form.length) {
+                $form.find('input, textarea, select, button').prop('disabled', true);
+            }
+
+            this.showMediaFormAlert($view, 'danger', message || 'Не удалось загрузить данные.');
         },
 
         setMediaLibraryViewMode: function (mode, $library) {
@@ -6809,6 +7219,54 @@ const Dashboard = {
             }
 
             return this.mediaAssetsIndex[key] || null;
+        },
+
+        getMediaViewUrl: function (assetId) {
+            var template = String(this.mediaViewUrlTemplate || '');
+            if (!template) {
+                return '';
+            }
+
+            var id = String(assetId || '');
+            if (!id) {
+                return '';
+            }
+
+            var encoded = encodeURIComponent(id);
+
+            return template.split('__id__').join(encoded);
+        },
+
+        getMediaTypeIcon: function (type) {
+            var map = {
+                image: 'picture-o',
+                video: 'film',
+                audio: 'music',
+                document: 'file-text-o',
+                archive: 'archive',
+                other: 'file-o'
+            };
+
+            var key = String(type || 'other');
+            return map[key] || map.other;
+        },
+
+        updateMediaAsset: function (asset) {
+            if (!asset || !asset.id) {
+                return;
+            }
+
+            var id = String(asset.id);
+            this.mediaAssetsIndex[id] = asset;
+
+            if ($.isArray(this.mediaAssetsDataset)) {
+                for (var index = 0; index < this.mediaAssetsDataset.length; index += 1) {
+                    if (String(this.mediaAssetsDataset[index].id) === id) {
+                        this.mediaAssetsDataset[index] = asset;
+                        break;
+                    }
+                }
+            }
         },
 
         formatFileSize: function (bytes) {

--- a/src/Http/Dashboard/Assets/js/pages/media.view.js
+++ b/src/Http/Dashboard/Assets/js/pages/media.view.js
@@ -1,0 +1,8 @@
+import Dashboard from '../core/legacy.js';
+import { App } from '../core/bootstrap.js';
+
+App.Modules['media.view'] = {
+    init(root) {
+        Dashboard.initMediaViewModule(root);
+    },
+};

--- a/src/Http/Dashboard/Controllers/MediaController.php
+++ b/src/Http/Dashboard/Controllers/MediaController.php
@@ -10,9 +10,212 @@ declare(strict_types=1);
 namespace Setka\Cms\Http\Dashboard\Controllers;
 
 use yii\web\Controller;
+use yii\web\NotFoundHttpException;
 
 final class MediaController extends Controller
 {
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private const MEDIA_ASSETS = [
+        [
+            'id' => 'asset-501',
+            'title' => 'Редакция в работе',
+            'filename' => 'team-working.jpg',
+            'type' => 'image',
+            'size' => 1245780,
+            'width' => 1920,
+            'height' => 1080,
+            'preview' => 'https://via.placeholder.com/600x400?text=Team',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Team',
+            'url' => 'https://cdn.example.com/assets/team-working.jpg',
+            'collection' => 'articles',
+            'collectionName' => 'Статьи',
+            'tags' => ['editorial', 'workflow'],
+            'description' => 'Динамичный снимок рабочей команды для презентаций и внутренних отчётов.',
+            'alt' => 'Команда за работой в редакции',
+            'source' => 'Внутренний фотобанк',
+            'createdAt' => '2025-03-08T10:15:00+03:00',
+            'updatedAt' => '2025-03-08T11:20:00+03:00',
+        ],
+        [
+            'id' => 'asset-502',
+            'title' => 'Главный баннер весны',
+            'filename' => 'hero-banner.png',
+            'type' => 'image',
+            'size' => 2150042,
+            'width' => 2560,
+            'height' => 1440,
+            'preview' => 'https://via.placeholder.com/600x400?text=Banner',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Banner',
+            'url' => 'https://cdn.example.com/assets/hero-banner.png',
+            'collection' => 'news',
+            'collectionName' => 'Новости',
+            'tags' => ['promo', 'homepage'],
+            'description' => 'Основной промо-баннер весенней кампании для главной страницы сайта.',
+            'alt' => 'Весенний промо-баннер',
+            'source' => 'Маркетинговый отдел',
+            'createdAt' => '2025-02-21T08:50:00+03:00',
+            'updatedAt' => '2025-03-01T09:10:00+03:00',
+        ],
+        [
+            'id' => 'asset-503',
+            'title' => 'Brand story 2025',
+            'filename' => 'brand-story.mp4',
+            'type' => 'video',
+            'size' => 18520480,
+            'duration' => 210,
+            'preview' => 'https://via.placeholder.com/600x400?text=Video',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Video',
+            'url' => 'https://cdn.example.com/assets/brand-story.mp4',
+            'collection' => 'interviews',
+            'collectionName' => 'Интервью',
+            'tags' => ['branding', 'events'],
+            'description' => 'Видеоролик с историей бренда, используемый для внешних анонсов и презентаций.',
+            'alt' => 'Превью ролика Brand story',
+            'source' => 'PR-команда',
+            'createdAt' => '2025-03-02T12:00:00+03:00',
+            'updatedAt' => '2025-03-05T14:00:00+03:00',
+        ],
+        [
+            'id' => 'asset-504',
+            'title' => 'Редакторский гайд 2025',
+            'filename' => 'editorial-guide.pdf',
+            'type' => 'document',
+            'size' => 842312,
+            'url' => 'https://cdn.example.com/assets/editorial-guide.pdf',
+            'collection' => 'articles',
+            'collectionName' => 'Статьи',
+            'tags' => ['workflow', 'guideline'],
+            'description' => 'PDF-руководство с обновлёнными правилами и стандартами работы редакции.',
+            'alt' => 'Редакторский гайд 2025',
+            'source' => 'Редакционный отдел',
+            'createdAt' => '2025-01-16T14:35:00+03:00',
+            'updatedAt' => '2025-02-01T10:05:00+03:00',
+        ],
+        [
+            'id' => 'asset-505',
+            'title' => 'Podcast intro 2025',
+            'filename' => 'podcast-intro.mp3',
+            'type' => 'audio',
+            'size' => 5234400,
+            'duration' => 95,
+            'url' => 'https://cdn.example.com/assets/podcast-intro.mp3',
+            'collection' => 'articles',
+            'collectionName' => 'Статьи',
+            'tags' => ['podcast', 'audio'],
+            'description' => 'Короткий аудиотрек для заставки корпоративного подкаста.',
+            'alt' => 'Аудиофайл podcast intro',
+            'source' => 'Звукорежиссёр студии',
+            'createdAt' => '2025-02-10T18:05:00+03:00',
+            'updatedAt' => '2025-02-15T12:45:00+03:00',
+        ],
+        [
+            'id' => 'asset-506',
+            'title' => 'Обложка рассылки март',
+            'filename' => 'newsletter-cover.jpg',
+            'type' => 'image',
+            'size' => 612304,
+            'width' => 1280,
+            'height' => 720,
+            'preview' => 'https://via.placeholder.com/600x400?text=Newsletter',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Newsletter',
+            'url' => 'https://cdn.example.com/assets/newsletter-cover.jpg',
+            'collection' => 'articles',
+            'collectionName' => 'Статьи',
+            'tags' => ['newsletter', 'promo'],
+            'description' => 'Изображение для мартовской email-рассылки в фирменном стиле.',
+            'alt' => 'Обложка мартовской рассылки',
+            'source' => 'Дизайн-команда',
+            'createdAt' => '2025-03-06T09:40:00+03:00',
+            'updatedAt' => '2025-03-06T10:00:00+03:00',
+        ],
+        [
+            'id' => 'asset-507',
+            'title' => 'Команда редакции',
+            'filename' => 'culture-team.jpg',
+            'type' => 'image',
+            'size' => 1480230,
+            'width' => 2048,
+            'height' => 1365,
+            'preview' => 'https://via.placeholder.com/600x400?text=Culture',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Culture',
+            'url' => 'https://cdn.example.com/assets/culture-team.jpg',
+            'collection' => 'interviews',
+            'collectionName' => 'Интервью',
+            'tags' => ['culture', 'people'],
+            'description' => 'Фотография команды для материалов о корпоративной культуре.',
+            'alt' => 'Редакционная команда на встрече',
+            'source' => 'HR-служба',
+            'createdAt' => '2025-02-28T11:20:00+03:00',
+            'updatedAt' => '2025-03-04T09:30:00+03:00',
+        ],
+        [
+            'id' => 'asset-508',
+            'title' => 'Media kit 2025',
+            'filename' => 'media-kit.zip',
+            'type' => 'archive',
+            'size' => 12288000,
+            'url' => 'https://cdn.example.com/assets/media-kit.zip',
+            'collection' => 'news',
+            'collectionName' => 'Новости',
+            'tags' => ['press', 'kit'],
+            'description' => 'Архив с медиакитом, логотипами и материалами для прессы.',
+            'alt' => 'Архив с медиакитом 2025',
+            'source' => 'PR-команда',
+            'createdAt' => '2024-12-18T16:10:00+03:00',
+            'updatedAt' => '2025-01-05T10:00:00+03:00',
+        ],
+        [
+            'id' => 'asset-509',
+            'title' => 'Интервью. Фрагмент видео',
+            'filename' => 'interview-snippet.mp4',
+            'type' => 'video',
+            'size' => 9520480,
+            'duration' => 135,
+            'preview' => 'https://via.placeholder.com/600x400?text=Interview',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Interview',
+            'url' => 'https://cdn.example.com/assets/interview-snippet.mp4',
+            'collection' => 'interviews',
+            'collectionName' => 'Интервью',
+            'tags' => ['video', 'product'],
+            'description' => 'Видео-фрагмент интервью с продуктовым менеджером.',
+            'alt' => 'Превью интервью с менеджером',
+            'source' => 'Видеоотдел',
+            'createdAt' => '2025-03-03T15:25:00+03:00',
+            'updatedAt' => '2025-03-04T08:45:00+03:00',
+        ],
+        [
+            'id' => 'asset-510',
+            'title' => 'Инфографика. Метрики',
+            'filename' => 'infographic-metrics.png',
+            'type' => 'image',
+            'size' => 1765340,
+            'width' => 2000,
+            'height' => 1125,
+            'preview' => 'https://via.placeholder.com/600x400?text=Metrics',
+            'thumb' => 'https://via.placeholder.com/360x220?text=Metrics',
+            'url' => 'https://cdn.example.com/assets/infographic-metrics.png',
+            'collection' => 'news',
+            'collectionName' => 'Новости',
+            'tags' => ['analytics', 'report'],
+            'description' => 'Инфографика с ключевыми метриками квартального отчёта.',
+            'alt' => 'Инфографика с основными метриками',
+            'source' => 'Аналитический отдел',
+            'createdAt' => '2025-01-28T10:05:00+03:00',
+            'updatedAt' => '2025-02-02T09:15:00+03:00',
+        ],
+    ];
+
+    private const MEDIA_TYPE_LABELS = [
+        'image' => 'Изображение',
+        'video' => 'Видео',
+        'audio' => 'Аудио',
+        'document' => 'Документ',
+        'archive' => 'Архив',
+        'other' => 'Файл',
+    ];
+
     public function actionLibrary(): string
     {
         return $this->render('library');
@@ -21,5 +224,83 @@ final class MediaController extends Controller
     public function actionUpload(): string
     {
         return $this->render('upload');
+    }
+
+    public function actionView(string $id): string
+    {
+        $asset = $this->findAsset($id);
+        if ($asset === null) {
+            throw new NotFoundHttpException('Медиафайл не найден.');
+        }
+
+        return $this->render('view', [
+            'asset' => $asset,
+            'availableCollections' => $this->collectCollections(),
+            'availableTags' => $this->collectTags(),
+            'typeLabels' => self::MEDIA_TYPE_LABELS,
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function collectCollections(): array
+    {
+        $collections = [];
+        foreach (self::MEDIA_ASSETS as $asset) {
+            $handle = (string)($asset['collection'] ?? '');
+            if ($handle === '') {
+                continue;
+            }
+
+            $label = (string)($asset['collectionName'] ?? $handle);
+            $collections[$handle] = $label;
+        }
+
+        ksort($collections, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $collections;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectTags(): array
+    {
+        $tags = [];
+        foreach (self::MEDIA_ASSETS as $asset) {
+            foreach ($asset['tags'] ?? [] as $tag) {
+                $normalized = (string)$tag;
+                if ($normalized === '') {
+                    continue;
+                }
+
+                $tags[$normalized] = true;
+            }
+        }
+
+        $result = array_keys($tags);
+        sort($result, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findAsset(string $id): ?array
+    {
+        $needle = trim($id);
+        if ($needle === '') {
+            return null;
+        }
+
+        foreach (self::MEDIA_ASSETS as $asset) {
+            if ((string)($asset['id'] ?? '') === $needle) {
+                return $asset;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Http/Dashboard/Module.php
+++ b/src/Http/Dashboard/Module.php
@@ -84,6 +84,7 @@ class Module extends BaseModule
                 'dashboard/entries' => 'dashboard/entries/index',
                 'dashboard/entries/data' => 'dashboard/entries/data',
                 'dashboard/collections/<handle:[A-Za-z0-9\-_]+>/entries/<id:[^/]+>/edit' => 'dashboard/entries/edit',
+                'dashboard/media/<id:[^/]+>/view' => 'dashboard/media/view',
                 'dashboard/elements/<id:[^/]+>/preview' => 'dashboard/elements/preview',
                 'dashboard/elements/<id:[^/]+>/history' => 'dashboard/elements/history',
                 'dashboard/schemas/create' => 'dashboard/schemas/create',

--- a/src/Http/Dashboard/Views/media/library.php
+++ b/src/Http/Dashboard/Views/media/library.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use yii\helpers\Html;
+use yii\helpers\Url;
 
 /* @var $this yii\web\View */
 
@@ -10,7 +11,9 @@ $this->title = 'Медиатека';
 $this->params['breadcrumbs'][] = $this->title;
 ?>
 
-<div class="box box-primary" data-role="media-library">
+<div class="box box-primary"
+     data-role="media-library"
+     data-media-view-url-template="<?= Html::encode(Url::to(['view', 'id' => '__id__'])) ?>">
     <div class="box-header with-border">
         <h3 class="box-title">Библиотека файлов</h3>
         <div class="box-tools">

--- a/src/Http/Dashboard/Views/media/view.php
+++ b/src/Http/Dashboard/Views/media/view.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use Yii;
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+/* @var $asset array<string, mixed> */
+/* @var $availableCollections array<string, string> */
+/* @var $availableTags list<string> */
+/* @var $typeLabels array<string, string> */
+
+$assetId = (string)($asset['id'] ?? '');
+$assetTitle = trim((string)($asset['title'] ?? ''));
+if ($assetTitle === '') {
+    $assetTitle = (string)($asset['filename'] ?? $assetId);
+}
+
+$this->title = $assetTitle !== '' ? 'Ассет: ' . $assetTitle : 'Ассет';
+$this->params['breadcrumbs'][] = ['label' => 'Медиатека', 'url' => ['library']];
+$this->params['breadcrumbs'][] = $this->title;
+
+$formatter = Yii::$app->formatter;
+$sizeLabel = isset($asset['size']) ? $formatter->asShortSize((int) $asset['size']) : '—';
+$dimensionsLabel = (isset($asset['width'], $asset['height']) && $asset['width'] && $asset['height'])
+    ? $asset['width'] . ' × ' . $asset['height'] . ' px'
+    : '—';
+$durationLabel = (isset($asset['duration']) && (int) $asset['duration'] > 0)
+    ? gmdate('i:s', (int) $asset['duration'])
+    : '—';
+$typeKey = (string)($asset['type'] ?? 'other');
+$typeLabel = $typeLabels[$typeKey] ?? ($typeLabels['other'] ?? 'Файл');
+$createdLabel = isset($asset['createdAt']) ? $formatter->asDatetime($asset['createdAt'], 'php:d.m.Y H:i') : '—';
+$updatedLabel = isset($asset['updatedAt']) ? $formatter->asDatetime($asset['updatedAt'], 'php:d.m.Y H:i') : '—';
+$tagsList = $asset['tags'] ?? [];
+$tagsLabel = $tagsList !== [] ? implode(', ', $tagsList) : '—';
+$description = trim((string)($asset['description'] ?? ''));
+$descriptionLabel = $description !== '' ? $description : '—';
+$collectionName = (string)($asset['collectionName'] ?? $asset['collection'] ?? '—');
+$iconMap = [
+    'image' => 'picture-o',
+    'video' => 'film',
+    'audio' => 'music',
+    'document' => 'file-text-o',
+    'archive' => 'archive',
+];
+$iconClass = $iconMap[$typeKey] ?? 'file-o';
+$previewUrl = (string)($asset['preview'] ?? $asset['thumb'] ?? '');
+if ($previewUrl === '' && $typeKey === 'image') {
+    $previewUrl = (string)($asset['url'] ?? '');
+}
+$downloadUrl = (string)($asset['url'] ?? '');
+?>
+
+<div class="row" data-role="media-view" data-asset-id="<?= Html::encode($assetId) ?>">
+    <div class="col-md-4">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title" data-role="media-heading"><?= Html::encode($assetTitle) ?></h3>
+            </div>
+            <div class="box-body">
+                <div class="media-preview" data-role="media-preview">
+                    <?php if ($previewUrl !== ''): ?>
+                        <img src="<?= Html::encode($previewUrl) ?>"
+                             alt="<?= Html::encode($asset['alt'] ?? $assetTitle) ?>"
+                             class="img-responsive img-rounded"
+                             data-role="media-preview-image">
+                    <?php else: ?>
+                        <div class="media-preview__placeholder text-center text-muted"
+                             data-role="media-preview-placeholder">
+                            <i class="fa fa-<?= Html::encode($iconClass) ?> fa-3x"
+                               data-role="media-preview-icon"></i>
+                            <p class="small">Предпросмотр появится после загрузки файла.</p>
+                        </div>
+                    <?php endif; ?>
+                </div>
+                <hr>
+                <dl class="dl-horizontal media-meta-list">
+                    <dt>Имя файла</dt>
+                    <dd data-role="meta-filename"><?= Html::encode($asset['filename'] ?? '—') ?></dd>
+                    <dt>Тип</dt>
+                    <dd data-role="meta-type"><?= Html::encode($typeLabel) ?></dd>
+                    <dt>Размер</dt>
+                    <dd data-role="meta-size"><?= Html::encode($sizeLabel) ?></dd>
+                    <dt>Разрешение</dt>
+                    <dd data-role="meta-dimensions"><?= Html::encode($dimensionsLabel) ?></dd>
+                    <dt>Длительность</dt>
+                    <dd data-role="meta-duration"><?= Html::encode($durationLabel) ?></dd>
+                    <dt>Коллекция</dt>
+                    <dd data-role="meta-collection"><?= Html::encode($collectionName) ?></dd>
+                    <dt>Теги</dt>
+                    <dd data-role="meta-tags"><?= Html::encode($tagsLabel) ?></dd>
+                    <dt>Описание</dt>
+                    <dd data-role="meta-description"><?= Html::encode($descriptionLabel) ?></dd>
+                    <dt>Создано</dt>
+                    <dd data-role="meta-created"><?= Html::encode($createdLabel) ?></dd>
+                    <dt>Обновлено</dt>
+                    <dd data-role="meta-updated"><?= Html::encode($updatedLabel) ?></dd>
+                    <dt>Ссылка</dt>
+                    <dd data-role="meta-url">
+                        <?php if ($downloadUrl !== ''): ?>
+                            <a href="<?= Html::encode($downloadUrl) ?>"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                <?= Html::encode($downloadUrl) ?>
+                            </a>
+                        <?php else: ?>
+                            <span class="text-muted">—</span>
+                        <?php endif; ?>
+                    </dd>
+                </dl>
+                <div class="alert alert-danger" data-role="media-error" style="display: none;"></div>
+            </div>
+            <div class="box-footer clearfix">
+                <div class="pull-left">
+                    <?= Html::a('<i class="fa fa-angle-left"></i> К списку', ['library'], [
+                        'class' => 'btn btn-default btn-sm',
+                        'data-pjax' => '0',
+                    ]) ?>
+                </div>
+                <?php if ($downloadUrl !== ''): ?>
+                    <div class="pull-right">
+                        <a href="<?= Html::encode($downloadUrl) ?>"
+                           class="btn btn-primary btn-sm"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           data-role="media-download">
+                            <i class="fa fa-download"></i> Скачать
+                        </a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-8">
+        <div class="box box-success" data-role="media-form-wrapper">
+            <div class="box-header with-border">
+                <h3 class="box-title">Редактирование метаданных</h3>
+            </div>
+            <form class="form-horizontal" data-role="media-form">
+                <div class="box-body">
+                    <div class="alert alert-info" data-role="media-alert" style="display: none;"></div>
+                    <input type="hidden" name="id" value="<?= Html::encode($assetId) ?>">
+                    <div class="form-group" data-field="title">
+                        <label class="col-sm-3 control-label" for="media-title">Название</label>
+                        <div class="col-sm-9">
+                            <input type="text"
+                                   class="form-control"
+                                   id="media-title"
+                                   name="title"
+                                   value="<?= Html::encode($assetTitle) ?>"
+                                   placeholder="Название файла">
+                            <p class="help-block" data-role="field-hint">Отображается в карточках медиатеки и поиске.</p>
+                            <p class="help-block text-danger" data-role="field-error" style="display: none;"></p>
+                        </div>
+                    </div>
+                    <div class="form-group" data-field="description">
+                        <label class="col-sm-3 control-label" for="media-description">Описание</label>
+                        <div class="col-sm-9">
+                            <textarea class="form-control"
+                                      rows="4"
+                                      id="media-description"
+                                      name="description"
+                                      placeholder="Кратко опишите назначение файла"><?= Html::encode($description) ?></textarea>
+                            <p class="help-block" data-role="field-hint">Используется при поиске и в карточке ассета.</p>
+                            <p class="help-block text-danger" data-role="field-error" style="display: none;"></p>
+                        </div>
+                    </div>
+                    <div class="form-group" data-field="collection">
+                        <label class="col-sm-3 control-label" for="media-collection">Коллекция</label>
+                        <div class="col-sm-9">
+                            <select id="media-collection"
+                                    name="collection"
+                                    class="form-control select2"
+                                    data-placeholder="Выберите коллекцию">
+                                <option value=""></option>
+                                <?php foreach ($availableCollections as $value => $label): ?>
+                                    <option value="<?= Html::encode($value) ?>"
+                                        <?= $value === ($asset['collection'] ?? '') ? 'selected' : '' ?>
+                                    ><?= Html::encode($label) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <p class="help-block" data-role="field-hint">Определяет, где ассет будет доступен редакторам.</p>
+                            <p class="help-block text-danger" data-role="field-error" style="display: none;"></p>
+                        </div>
+                    </div>
+                    <div class="form-group" data-field="tags">
+                        <label class="col-sm-3 control-label" for="media-tags">Теги</label>
+                        <div class="col-sm-9">
+                            <select id="media-tags"
+                                    class="form-control select2"
+                                    name="tags[]"
+                                    multiple
+                                    data-placeholder="Выберите или добавьте теги">
+                                <?php foreach ($availableTags as $tag): ?>
+                                    <option value="<?= Html::encode($tag) ?>"
+                                        <?= in_array($tag, $tagsList, true) ? 'selected' : '' ?>
+                                    ><?= Html::encode($tag) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <p class="help-block" data-role="field-hint">Помогают фильтровать и находить материалы.</p>
+                            <p class="help-block text-danger" data-role="field-error" style="display: none;"></p>
+                        </div>
+                    </div>
+                    <div class="form-group" data-field="alt">
+                        <label class="col-sm-3 control-label" for="media-alt">Альтернативный текст</label>
+                        <div class="col-sm-9">
+                            <input type="text"
+                                   class="form-control"
+                                   id="media-alt"
+                                   name="alt"
+                                   value="<?= Html::encode($asset['alt'] ?? '') ?>"
+                                   placeholder="Описание изображения для доступности">
+                            <p class="help-block" data-role="field-hint">Отображается для экранных дикторов и при ошибках загрузки.</p>
+                            <p class="help-block text-danger" data-role="field-error" style="display: none;"></p>
+                        </div>
+                    </div>
+                    <div class="form-group" data-field="source">
+                        <label class="col-sm-3 control-label" for="media-source">Источник</label>
+                        <div class="col-sm-9">
+                            <input type="text"
+                                   class="form-control"
+                                   id="media-source"
+                                   name="source"
+                                   value="<?= Html::encode($asset['source'] ?? '') ?>"
+                                   placeholder="Например: пресс-служба, фотосток">
+                            <p class="help-block" data-role="field-hint">Добавьте происхождение файла для корректного указания прав.</p>
+                            <p class="help-block text-danger" data-role="field-error" style="display: none;"></p>
+                        </div>
+                    </div>
+                </div>
+                <div class="box-footer clearfix">
+                    <div class="pull-left">
+                        <button type="button" class="btn btn-default btn-sm" data-action="media-reset">
+                            Сбросить изменения
+                        </button>
+                    </div>
+                    <div class="pull-right">
+                        <button type="submit" class="btn btn-success" data-role="media-save">
+                            <i class="fa fa-check"></i> Сохранить
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- расширен `MediaController` моковыми ассетами и добавлен экшен просмотра, передающий данные в представление
- создан шаблон `media/view` с предпросмотром и формой редактирования метаданных
- подключён модуль `media.view`, доработан `legacy.js` для перехода из медиатеки, заполнения формы и валидации
- добавлен маршрут `/dashboard/media/<id>/view` и привязка ссылки в медиатеке

## Testing
- composer test *(ошибка: phpunit не найден в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68ced2c5ea58832d9b0501f9aa1f53af